### PR TITLE
Add database models and taxpayer API

### DIFF
--- a/app/core/database.py
+++ b/app/core/database.py
@@ -25,3 +25,8 @@ AsyncSessionLocal = sessionmaker(
 )
 
 Base = declarative_base()
+
+
+async def get_session() -> AsyncSession:
+    async with AsyncSessionLocal() as session:
+        yield session

--- a/app/crud/__init__.py
+++ b/app/crud/__init__.py
@@ -1,0 +1,13 @@
+from .taxpayer import (
+    get_taxpayer,
+    search_taxpayers,
+    create_taxpayer,
+    update_taxpayer,
+)
+
+__all__ = [
+    'get_taxpayer',
+    'search_taxpayers',
+    'create_taxpayer',
+    'update_taxpayer',
+]

--- a/app/crud/taxpayer.py
+++ b/app/crud/taxpayer.py
@@ -1,0 +1,41 @@
+from typing import List, Optional
+from sqlalchemy.future import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.taxpayer import Taxpayer
+
+
+async def get_taxpayer(db: AsyncSession, taxpayer_id: str) -> Optional[Taxpayer]:
+    result = await db.execute(select(Taxpayer).where(Taxpayer.taxpayer_id == taxpayer_id))
+    return result.scalar_one_or_none()
+
+
+async def search_taxpayers(db: AsyncSession, query: str) -> List[Taxpayer]:
+    stmt = select(Taxpayer)
+    if query:
+        like_pattern = f"%{query}%"
+        stmt = stmt.where(
+            (Taxpayer.taxpayer_id == query) |
+            (Taxpayer.last_name.ilike(like_pattern)) |
+            (Taxpayer.first_name.ilike(like_pattern)) |
+            (Taxpayer.middle_name.ilike(like_pattern)) |
+            (Taxpayer.company_name.ilike(like_pattern))
+        )
+    result = await db.execute(stmt)
+    return result.scalars().all()
+
+
+async def create_taxpayer(db: AsyncSession, data: dict) -> Taxpayer:
+    taxpayer = Taxpayer(**data)
+    db.add(taxpayer)
+    await db.commit()
+    await db.refresh(taxpayer)
+    return taxpayer
+
+
+async def update_taxpayer(db: AsyncSession, taxpayer: Taxpayer, data: dict) -> Taxpayer:
+    for key, value in data.items():
+        setattr(taxpayer, key, value)
+    await db.commit()
+    await db.refresh(taxpayer)
+    return taxpayer

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -1,0 +1,23 @@
+from .region import Region
+from .taxtype import TaxType
+from .taxpayer import Taxpayer
+from .employee import Employee
+from .taxdeclaration import TaxDeclaration
+from .accrual import Accrual
+from .payment import Payment
+from .debt import Debt
+from .inspection import Inspection
+from .auditlog import AuditLog
+
+__all__ = [
+    'Region',
+    'TaxType',
+    'Taxpayer',
+    'Employee',
+    'TaxDeclaration',
+    'Accrual',
+    'Payment',
+    'Debt',
+    'Inspection',
+    'AuditLog',
+]

--- a/app/models/accrual.py
+++ b/app/models/accrual.py
@@ -1,0 +1,19 @@
+from sqlalchemy import Column, Integer, String, Numeric, Date, Enum
+from app.core.database import Base
+
+
+class Accrual(Base):
+    __tablename__ = "Accrual"
+
+    accrual_id = Column(Integer, primary_key=True, autoincrement=True)
+    taxpayer_id = Column(String(12), nullable=False)
+    tax_type_id = Column(String(10), nullable=False)
+    period = Column(Integer, nullable=False)
+    amount = Column(Numeric(15, 2), nullable=False)
+    paid_amount = Column(Numeric(15, 2), nullable=False, default=0)
+    due_date = Column(Date, nullable=False)
+    declaration_id = Column(Integer)
+    status = Column(
+        Enum('начислено', 'оплачено частично', 'оплачено', 'просрочено'),
+        default='начислено'
+    )

--- a/app/models/auditlog.py
+++ b/app/models/auditlog.py
@@ -1,0 +1,16 @@
+from sqlalchemy import Column, Integer, String, Text, Enum, TIMESTAMP
+from sqlalchemy.sql import func
+from app.core.database import Base
+
+
+class AuditLog(Base):
+    __tablename__ = "AuditLog"
+
+    audit_id = Column(Integer, primary_key=True, autoincrement=True)
+    event_time = Column(TIMESTAMP, server_default=func.current_timestamp())
+    user_name = Column(String(100), nullable=False)
+    action_type = Column(Enum('INSERT', 'UPDATE', 'DELETE'), nullable=False)
+    table_name = Column(String(64), nullable=False)
+    record_id = Column(String(64), nullable=False)
+    old_values = Column(Text)
+    new_values = Column(Text)

--- a/app/models/debt.py
+++ b/app/models/debt.py
@@ -1,0 +1,13 @@
+from sqlalchemy import Column, Integer, Numeric, Date, Enum
+from app.core.database import Base
+
+
+class Debt(Base):
+    __tablename__ = "Debt"
+
+    debt_id = Column(Integer, primary_key=True, autoincrement=True)
+    accrual_id = Column(Integer, nullable=False, unique=True)
+    principal_amount = Column(Numeric(15, 2), nullable=False)
+    penalty_amount = Column(Numeric(15, 2), nullable=False, default=0)
+    penalty_date = Column(Date, nullable=False)
+    status = Column(Enum('активно', 'погашено'), default='активно')

--- a/app/models/employee.py
+++ b/app/models/employee.py
@@ -1,0 +1,14 @@
+from sqlalchemy import Column, Integer, String, Enum
+from app.core.database import Base
+
+
+class Employee(Base):
+    __tablename__ = "Employee"
+
+    employee_id = Column(Integer, primary_key=True, autoincrement=True)
+    name = Column(String(100), nullable=False)
+    position = Column(String(100), nullable=False)
+    department = Column(String(100))
+    role = Column(Enum('INSPECTOR', 'ADMIN'), nullable=False)
+    phone = Column(String(20))
+    email = Column(String(50))

--- a/app/models/inspection.py
+++ b/app/models/inspection.py
@@ -1,0 +1,16 @@
+from sqlalchemy import Column, Integer, String, Date, Enum, Numeric, Text
+from app.core.database import Base
+
+
+class Inspection(Base):
+    __tablename__ = "Inspection"
+
+    inspection_id = Column(Integer, primary_key=True, autoincrement=True)
+    taxpayer_id = Column(String(12), nullable=False)
+    employee_id = Column(Integer, nullable=False)
+    type = Column(Enum('камеральная', 'выездная'), nullable=False)
+    start_date = Column(Date, nullable=False)
+    end_date = Column(Date)
+    result = Column(Text)
+    additional_tax = Column(Numeric(15, 2), default=0)
+    fine_amount = Column(Numeric(15, 2), default=0)

--- a/app/models/payment.py
+++ b/app/models/payment.py
@@ -1,0 +1,12 @@
+from sqlalchemy import Column, Integer, String, Date, Numeric
+from app.core.database import Base
+
+
+class Payment(Base):
+    __tablename__ = "Payment"
+
+    payment_id = Column(Integer, primary_key=True, autoincrement=True)
+    taxpayer_id = Column(String(12), nullable=False)
+    accrual_id = Column(Integer, nullable=False)
+    payment_date = Column(Date, nullable=False)
+    amount = Column(Numeric(15, 2), nullable=False)

--- a/app/models/region.py
+++ b/app/models/region.py
@@ -1,0 +1,9 @@
+from sqlalchemy import Column, SmallInteger, String
+from app.core.database import Base
+
+
+class Region(Base):
+    __tablename__ = "Region"
+
+    region_code = Column(SmallInteger, primary_key=True, autoincrement=False)
+    region_name = Column(String(100), nullable=False)

--- a/app/models/taxdeclaration.py
+++ b/app/models/taxdeclaration.py
@@ -1,0 +1,18 @@
+from sqlalchemy import Column, Integer, String, Date, Enum, Numeric
+from sqlalchemy.orm import relationship
+from app.core.database import Base
+
+
+class TaxDeclaration(Base):
+    __tablename__ = "TaxDeclaration"
+
+    declaration_id = Column(Integer, primary_key=True, autoincrement=True)
+    taxpayer_id = Column(String(12), nullable=False)
+    tax_type_id = Column(String(10), nullable=False)
+    period = Column(Integer, nullable=False)
+    submission_date = Column(Date, nullable=False)
+    declared_tax_amount = Column(Numeric(15, 2), nullable=False)
+    status = Column(
+        Enum('принята', 'на проверке', 'выявлены ошибки', 'утверждена'),
+        default='принята'
+    )

--- a/app/models/taxpayer.py
+++ b/app/models/taxpayer.py
@@ -1,0 +1,30 @@
+from sqlalchemy import Column, String, Enum, Date, SmallInteger
+from app.core.database import Base
+
+
+class Taxpayer(Base):
+    __tablename__ = "Taxpayer"
+
+    taxpayer_id = Column(String(12), primary_key=True)
+    type = Column(Enum('F', 'U'), nullable=False)
+
+    # Physical person
+    last_name = Column(String(50))
+    first_name = Column(String(50))
+    middle_name = Column(String(50))
+    birth_date = Column(Date)
+    passport_no = Column(String(20))
+    passport_date = Column(Date)
+
+    # Legal entity
+    company_name = Column(String(100))
+    ogrn = Column(String(15))
+
+    # Address
+    region_code = Column(SmallInteger)
+    city = Column(String(50))
+    street = Column(String(100))
+    house = Column(String(10))
+    apartment = Column(String(10))
+    phone = Column(String(20))
+    email = Column(String(50))

--- a/app/models/taxtype.py
+++ b/app/models/taxtype.py
@@ -1,0 +1,10 @@
+from sqlalchemy import Column, String, Text
+from app.core.database import Base
+
+
+class TaxType(Base):
+    __tablename__ = "TaxType"
+
+    tax_type_id = Column(String(10), primary_key=True)
+    tax_name = Column(String(100), nullable=False)
+    description = Column(Text)

--- a/app/routes/__init__.py
+++ b/app/routes/__init__.py
@@ -1,0 +1,7 @@
+from fastapi import APIRouter
+from . import taxpayers
+
+api_router = APIRouter()
+api_router.include_router(taxpayers.router, prefix='/taxpayers', tags=['Taxpayers'])
+
+__all__ = ['api_router']

--- a/app/routes/taxpayers.py
+++ b/app/routes/taxpayers.py
@@ -1,0 +1,40 @@
+from typing import List
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.database import get_session
+from app.crud import (
+    get_taxpayer,
+    search_taxpayers,
+    create_taxpayer,
+    update_taxpayer,
+)
+from app.schemas import TaxpayerCreate, TaxpayerUpdate, TaxpayerRead
+
+router = APIRouter()
+
+
+@router.get('/search', response_model=List[TaxpayerRead])
+async def search(query: str, db: AsyncSession = Depends(get_session)):
+    return await search_taxpayers(db, query)
+
+
+@router.get('/{taxpayer_id}', response_model=TaxpayerRead)
+async def read_taxpayer(taxpayer_id: str, db: AsyncSession = Depends(get_session)):
+    taxpayer = await get_taxpayer(db, taxpayer_id)
+    if not taxpayer:
+        raise HTTPException(status_code=404, detail='Taxpayer not found')
+    return taxpayer
+
+
+@router.post('/', response_model=TaxpayerRead)
+async def create(tp: TaxpayerCreate, db: AsyncSession = Depends(get_session)):
+    return await create_taxpayer(db, tp.dict())
+
+
+@router.put('/{taxpayer_id}', response_model=TaxpayerRead)
+async def update(taxpayer_id: str, tp: TaxpayerUpdate, db: AsyncSession = Depends(get_session)):
+    taxpayer = await get_taxpayer(db, taxpayer_id)
+    if not taxpayer:
+        raise HTTPException(status_code=404, detail='Taxpayer not found')
+    return await update_taxpayer(db, taxpayer, tp.dict(exclude_unset=True))

--- a/app/schemas/__init__.py
+++ b/app/schemas/__init__.py
@@ -1,0 +1,7 @@
+from .taxpayer import TaxpayerCreate, TaxpayerUpdate, TaxpayerRead
+
+__all__ = [
+    'TaxpayerCreate',
+    'TaxpayerUpdate',
+    'TaxpayerRead',
+]

--- a/app/schemas/taxpayer.py
+++ b/app/schemas/taxpayer.py
@@ -1,0 +1,50 @@
+from datetime import date
+from pydantic import BaseModel, Field
+from typing import Optional
+
+
+class TaxpayerBase(BaseModel):
+    taxpayer_id: str = Field(..., max_length=12)
+    type: str
+    last_name: Optional[str] = None
+    first_name: Optional[str] = None
+    middle_name: Optional[str] = None
+    birth_date: Optional[date] = None
+    passport_no: Optional[str] = None
+    passport_date: Optional[date] = None
+    company_name: Optional[str] = None
+    ogrn: Optional[str] = None
+    region_code: Optional[int] = None
+    city: Optional[str] = None
+    street: Optional[str] = None
+    house: Optional[str] = None
+    apartment: Optional[str] = None
+    phone: Optional[str] = None
+    email: Optional[str] = None
+
+
+class TaxpayerCreate(TaxpayerBase):
+    pass
+
+
+class TaxpayerUpdate(BaseModel):
+    last_name: Optional[str] = None
+    first_name: Optional[str] = None
+    middle_name: Optional[str] = None
+    birth_date: Optional[date] = None
+    passport_no: Optional[str] = None
+    passport_date: Optional[date] = None
+    company_name: Optional[str] = None
+    ogrn: Optional[str] = None
+    region_code: Optional[int] = None
+    city: Optional[str] = None
+    street: Optional[str] = None
+    house: Optional[str] = None
+    apartment: Optional[str] = None
+    phone: Optional[str] = None
+    email: Optional[str] = None
+
+
+class TaxpayerRead(TaxpayerBase):
+    class Config:
+        orm_mode = True

--- a/main.py
+++ b/main.py
@@ -1,10 +1,8 @@
 # main.py
 from fastapi import FastAPI
-# from app.routes import taxpayers, declarations, payments  # будете добавлять
+from app.routes import api_router
 
 app = FastAPI(title="АИС «Налог‑Учёт»")
 
-# Регистрируем роутеры
-# app.include_router(taxpayers.router, prefix="/taxpayers", tags=["Taxpayers"])
-# app.include_router(declarations.router, prefix="/declarations", tags=["Declarations"])
-# app.include_router(payments.router, prefix="/payments", tags=["Payments"])
+# Register routers
+app.include_router(api_router)


### PR DESCRIPTION
## Summary
- implement SQLAlchemy models for database tables
- create CRUD operations and API routes for taxpayers
- wire up routers in main application

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6850d0ea4c64832c9ae13dc4f9a1f36c