### PR TITLE
Implement declarations and payments API

### DIFF
--- a/app/crud/__init__.py
+++ b/app/crud/__init__.py
@@ -4,10 +4,16 @@ from .taxpayer import (
     create_taxpayer,
     update_taxpayer,
 )
+from .declaration import get_declaration, create_declaration
+from .payment import get_payment, create_payment
 
 __all__ = [
     'get_taxpayer',
     'search_taxpayers',
     'create_taxpayer',
     'update_taxpayer',
+    'get_declaration',
+    'create_declaration',
+    'get_payment',
+    'create_payment',
 ]

--- a/app/crud/declaration.py
+++ b/app/crud/declaration.py
@@ -1,0 +1,32 @@
+from datetime import timedelta
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.future import select
+
+from app.models.taxdeclaration import TaxDeclaration
+from app.models.accrual import Accrual
+
+
+async def get_declaration(db: AsyncSession, declaration_id: int):
+    result = await db.execute(
+        select(TaxDeclaration).where(TaxDeclaration.declaration_id == declaration_id)
+    )
+    return result.scalar_one_or_none()
+
+
+async def create_declaration(db: AsyncSession, data: dict) -> TaxDeclaration:
+    declaration = TaxDeclaration(**data)
+    db.add(declaration)
+    await db.flush()
+
+    accrual = Accrual(
+        taxpayer_id=declaration.taxpayer_id,
+        tax_type_id=declaration.tax_type_id,
+        period=declaration.period,
+        amount=declaration.declared_tax_amount,
+        due_date=declaration.submission_date + timedelta(days=90),
+        declaration_id=declaration.declaration_id,
+    )
+    db.add(accrual)
+    await db.commit()
+    await db.refresh(declaration)
+    return declaration

--- a/app/crud/payment.py
+++ b/app/crud/payment.py
@@ -1,0 +1,31 @@
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.future import select
+
+from app.models.payment import Payment
+from app.models.accrual import Accrual
+
+
+async def get_payment(db: AsyncSession, payment_id: int):
+    result = await db.execute(select(Payment).where(Payment.payment_id == payment_id))
+    return result.scalar_one_or_none()
+
+
+async def create_payment(db: AsyncSession, data: dict) -> Payment:
+    accrual = await db.get(Accrual, data['accrual_id'])
+    if accrual is None or accrual.taxpayer_id != data['taxpayer_id']:
+        raise ValueError('Accrual not found')
+    if accrual.paid_amount + data['amount'] > accrual.amount:
+        raise ValueError('Payment exceeds accrual amount')
+
+    payment = Payment(**data)
+    db.add(payment)
+
+    accrual.paid_amount += data['amount']
+    if accrual.paid_amount == accrual.amount:
+        accrual.status = 'оплачено'
+    else:
+        accrual.status = 'оплачено частично'
+
+    await db.commit()
+    await db.refresh(payment)
+    return payment

--- a/app/routes/__init__.py
+++ b/app/routes/__init__.py
@@ -1,7 +1,9 @@
 from fastapi import APIRouter
-from . import taxpayers
+from . import taxpayers, declarations, payments
 
 api_router = APIRouter()
 api_router.include_router(taxpayers.router, prefix='/taxpayers', tags=['Taxpayers'])
+api_router.include_router(declarations.router, prefix='/declarations', tags=['Declarations'])
+api_router.include_router(payments.router, prefix='/payments', tags=['Payments'])
 
 __all__ = ['api_router']

--- a/app/routes/declarations.py
+++ b/app/routes/declarations.py
@@ -1,0 +1,21 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.database import get_session
+from app.crud import get_declaration, create_declaration
+from app.schemas import TaxDeclarationCreate, TaxDeclarationRead
+
+router = APIRouter()
+
+
+@router.post('/', response_model=TaxDeclarationRead)
+async def create(decl: TaxDeclarationCreate, db: AsyncSession = Depends(get_session)):
+    return await create_declaration(db, decl.dict())
+
+
+@router.get('/{declaration_id}', response_model=TaxDeclarationRead)
+async def read(declaration_id: int, db: AsyncSession = Depends(get_session)):
+    declaration = await get_declaration(db, declaration_id)
+    if not declaration:
+        raise HTTPException(status_code=404, detail='Declaration not found')
+    return declaration

--- a/app/routes/payments.py
+++ b/app/routes/payments.py
@@ -1,0 +1,24 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.database import get_session
+from app.crud import get_payment, create_payment
+from app.schemas import PaymentCreate, PaymentRead
+
+router = APIRouter()
+
+
+@router.post('/', response_model=PaymentRead)
+async def create(pay: PaymentCreate, db: AsyncSession = Depends(get_session)):
+    try:
+        return await create_payment(db, pay.dict())
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@router.get('/{payment_id}', response_model=PaymentRead)
+async def read(payment_id: int, db: AsyncSession = Depends(get_session)):
+    payment = await get_payment(db, payment_id)
+    if not payment:
+        raise HTTPException(status_code=404, detail='Payment not found')
+    return payment

--- a/app/schemas/__init__.py
+++ b/app/schemas/__init__.py
@@ -1,7 +1,15 @@
 from .taxpayer import TaxpayerCreate, TaxpayerUpdate, TaxpayerRead
+from .declaration import TaxDeclarationCreate, TaxDeclarationRead
+from .payment import PaymentCreate, PaymentRead
+from .accrual import AccrualRead
 
 __all__ = [
     'TaxpayerCreate',
     'TaxpayerUpdate',
     'TaxpayerRead',
+    'TaxDeclarationCreate',
+    'TaxDeclarationRead',
+    'PaymentCreate',
+    'PaymentRead',
+    'AccrualRead',
 ]

--- a/app/schemas/accrual.py
+++ b/app/schemas/accrual.py
@@ -1,0 +1,20 @@
+from datetime import date
+from decimal import Decimal
+from typing import Optional
+
+from pydantic import BaseModel
+
+
+class AccrualRead(BaseModel):
+    accrual_id: int
+    taxpayer_id: str
+    tax_type_id: str
+    period: int
+    amount: Decimal
+    paid_amount: Decimal
+    due_date: date
+    declaration_id: Optional[int] = None
+    status: str
+
+    class Config:
+        orm_mode = True

--- a/app/schemas/declaration.py
+++ b/app/schemas/declaration.py
@@ -1,0 +1,25 @@
+from datetime import date
+from decimal import Decimal
+from typing import Optional
+
+from pydantic import BaseModel
+
+
+class TaxDeclarationBase(BaseModel):
+    taxpayer_id: str
+    tax_type_id: str
+    period: int
+    submission_date: date
+    declared_tax_amount: Decimal
+
+
+class TaxDeclarationCreate(TaxDeclarationBase):
+    pass
+
+
+class TaxDeclarationRead(TaxDeclarationBase):
+    declaration_id: int
+    status: Optional[str] = None
+
+    class Config:
+        orm_mode = True

--- a/app/schemas/payment.py
+++ b/app/schemas/payment.py
@@ -1,0 +1,22 @@
+from datetime import date
+from decimal import Decimal
+
+from pydantic import BaseModel
+
+
+class PaymentBase(BaseModel):
+    taxpayer_id: str
+    accrual_id: int
+    payment_date: date
+    amount: Decimal
+
+
+class PaymentCreate(PaymentBase):
+    pass
+
+
+class PaymentRead(PaymentBase):
+    payment_id: int
+
+    class Config:
+        orm_mode = True


### PR DESCRIPTION
## Summary
- add schemas for declarations, accruals and payments
- create CRUD utils for declarations and payments
- expose new routers for declarations and payments
- automatically create accrual on declaration
- update accrual status on payment

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850d815185c832c83c6fd475ec5b330