### PR TITLE
Add debt calculation and inspection journal

### DIFF
--- a/app/crud/__init__.py
+++ b/app/crud/__init__.py
@@ -6,6 +6,8 @@ from .taxpayer import (
 )
 from .declaration import get_declaration, create_declaration
 from .payment import get_payment, create_payment
+from .debt import calculate_debts
+from .inspection import get_inspection, list_inspections, create_inspection
 
 __all__ = [
     'get_taxpayer',
@@ -16,4 +18,8 @@ __all__ = [
     'create_declaration',
     'get_payment',
     'create_payment',
+    'calculate_debts',
+    'get_inspection',
+    'list_inspections',
+    'create_inspection',
 ]

--- a/app/crud/debt.py
+++ b/app/crud/debt.py
@@ -1,0 +1,58 @@
+from datetime import date
+from typing import List
+
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.future import select
+
+from app.models import Accrual, Debt
+
+# Fixed reference rate used in README examples
+REF_RATE = 7.50
+
+
+async def calculate_debts(db: AsyncSession, taxpayer_id: str) -> List[Debt]:
+    today = date.today()
+    result = await db.execute(
+        select(Accrual).where(
+            Accrual.taxpayer_id == taxpayer_id,
+            Accrual.due_date < today,
+            Accrual.status != 'оплачено',
+        )
+    )
+    accruals = result.scalars().all()
+
+    for accrual in accruals:
+        principal = float(accrual.amount) - float(accrual.paid_amount)
+        if principal <= 0:
+            continue
+        debt_result = await db.execute(
+            select(Debt).where(Debt.accrual_id == accrual.accrual_id)
+        )
+        debt = debt_result.scalar_one_or_none()
+        if debt is None:
+            debt = Debt(
+                accrual_id=accrual.accrual_id,
+                principal_amount=principal,
+                penalty_amount=0,
+                penalty_date=today,
+                status='активно',
+            )
+            db.add(debt)
+        else:
+            debt.principal_amount = principal
+            if debt.status == 'активно':
+                days = (today - debt.penalty_date).days
+                if days > 0:
+                    debt.penalty_amount += round(
+                        float(debt.principal_amount) * REF_RATE / 300 * days, 2
+                    )
+                    debt.penalty_date = today
+            if principal == 0:
+                debt.status = 'погашено'
+
+    await db.commit()
+
+    result = await db.execute(
+        select(Debt).join(Accrual).where(Accrual.taxpayer_id == taxpayer_id)
+    )
+    return result.scalars().all()

--- a/app/crud/inspection.py
+++ b/app/crud/inspection.py
@@ -1,0 +1,28 @@
+from typing import List, Optional
+
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.future import select
+
+from app.models import Inspection
+
+
+async def get_inspection(db: AsyncSession, inspection_id: int) -> Optional[Inspection]:
+    result = await db.execute(
+        select(Inspection).where(Inspection.inspection_id == inspection_id)
+    )
+    return result.scalar_one_or_none()
+
+
+async def list_inspections(db: AsyncSession, taxpayer_id: str) -> List[Inspection]:
+    result = await db.execute(
+        select(Inspection).where(Inspection.taxpayer_id == taxpayer_id)
+    )
+    return result.scalars().all()
+
+
+async def create_inspection(db: AsyncSession, data: dict) -> Inspection:
+    inspection = Inspection(**data)
+    db.add(inspection)
+    await db.commit()
+    await db.refresh(inspection)
+    return inspection

--- a/app/routes/__init__.py
+++ b/app/routes/__init__.py
@@ -1,9 +1,11 @@
 from fastapi import APIRouter
-from . import taxpayers, declarations, payments
+from . import taxpayers, declarations, payments, debts, inspections
 
 api_router = APIRouter()
 api_router.include_router(taxpayers.router, prefix='/taxpayers', tags=['Taxpayers'])
 api_router.include_router(declarations.router, prefix='/declarations', tags=['Declarations'])
 api_router.include_router(payments.router, prefix='/payments', tags=['Payments'])
+api_router.include_router(debts.router, prefix='/debts', tags=['Debts'])
+api_router.include_router(inspections.router, prefix='/inspections', tags=['Inspections'])
 
 __all__ = ['api_router']

--- a/app/routes/debts.py
+++ b/app/routes/debts.py
@@ -1,0 +1,15 @@
+from typing import List
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.database import get_session
+from app.crud import calculate_debts
+from app.schemas import DebtRead
+
+router = APIRouter()
+
+
+@router.get('/{taxpayer_id}', response_model=List[DebtRead])
+async def read_debts(taxpayer_id: str, db: AsyncSession = Depends(get_session)):
+    return await calculate_debts(db, taxpayer_id)

--- a/app/routes/inspections.py
+++ b/app/routes/inspections.py
@@ -1,0 +1,32 @@
+from typing import List
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.database import get_session
+from app.crud import (
+    get_inspection,
+    list_inspections,
+    create_inspection,
+)
+from app.schemas import InspectionCreate, InspectionRead
+
+router = APIRouter()
+
+
+@router.post('/', response_model=InspectionRead)
+async def create(ins: InspectionCreate, db: AsyncSession = Depends(get_session)):
+    return await create_inspection(db, ins.dict())
+
+
+@router.get('/{inspection_id}', response_model=InspectionRead)
+async def read(inspection_id: int, db: AsyncSession = Depends(get_session)):
+    inspection = await get_inspection(db, inspection_id)
+    if not inspection:
+        raise HTTPException(status_code=404, detail='Inspection not found')
+    return inspection
+
+
+@router.get('/by_taxpayer/{taxpayer_id}', response_model=List[InspectionRead])
+async def by_taxpayer(taxpayer_id: str, db: AsyncSession = Depends(get_session)):
+    return await list_inspections(db, taxpayer_id)

--- a/app/schemas/__init__.py
+++ b/app/schemas/__init__.py
@@ -2,6 +2,8 @@ from .taxpayer import TaxpayerCreate, TaxpayerUpdate, TaxpayerRead
 from .declaration import TaxDeclarationCreate, TaxDeclarationRead
 from .payment import PaymentCreate, PaymentRead
 from .accrual import AccrualRead
+from .debt import DebtRead
+from .inspection import InspectionCreate, InspectionRead
 
 __all__ = [
     'TaxpayerCreate',
@@ -12,4 +14,7 @@ __all__ = [
     'PaymentCreate',
     'PaymentRead',
     'AccrualRead',
+    'DebtRead',
+    'InspectionCreate',
+    'InspectionRead',
 ]

--- a/app/schemas/debt.py
+++ b/app/schemas/debt.py
@@ -1,0 +1,15 @@
+from datetime import date
+from decimal import Decimal
+from pydantic import BaseModel
+
+
+class DebtRead(BaseModel):
+    debt_id: int
+    accrual_id: int
+    principal_amount: Decimal
+    penalty_amount: Decimal
+    penalty_date: date
+    status: str
+
+    class Config:
+        orm_mode = True

--- a/app/schemas/inspection.py
+++ b/app/schemas/inspection.py
@@ -1,0 +1,27 @@
+from datetime import date
+from decimal import Decimal
+from typing import Optional
+
+from pydantic import BaseModel
+
+
+class InspectionBase(BaseModel):
+    taxpayer_id: str
+    employee_id: int
+    type: str
+    start_date: date
+    end_date: Optional[date] = None
+    result: Optional[str] = None
+    additional_tax: Decimal = Decimal('0')
+    fine_amount: Decimal = Decimal('0')
+
+
+class InspectionCreate(InspectionBase):
+    pass
+
+
+class InspectionRead(InspectionBase):
+    inspection_id: int
+
+    class Config:
+        orm_mode = True


### PR DESCRIPTION
## Summary
- implement debt calculations
- add inspection journal CRUD and routes
- expose debt and inspection routes in API router
- add schemas for debt and inspection

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6850ddf97e0c832c9781618434417da7