### PR TITLE
Добавлены отчёты по налогам и должникам

### DIFF
--- a/app/crud/__init__.py
+++ b/app/crud/__init__.py
@@ -8,6 +8,7 @@ from .declaration import get_declaration, create_declaration
 from .payment import get_payment, create_payment
 from .debt import calculate_debts
 from .inspection import get_inspection, list_inspections, create_inspection
+from .report import tax_revenue_report, debtors_list
 
 __all__ = [
     'get_taxpayer',
@@ -22,4 +23,6 @@ __all__ = [
     'get_inspection',
     'list_inspections',
     'create_inspection',
+    'tax_revenue_report',
+    'debtors_list',
 ]

--- a/app/crud/report.py
+++ b/app/crud/report.py
@@ -1,0 +1,74 @@
+from typing import List, Dict
+from decimal import Decimal
+
+from sqlalchemy import select, func
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models import Payment, Accrual, TaxType, Taxpayer, Debt
+from .debt import calculate_debts
+
+
+async def tax_revenue_report(db: AsyncSession) -> List[Dict]:
+    result = await db.execute(
+        select(
+            Accrual.tax_type_id,
+            TaxType.tax_name,
+            func.sum(Payment.amount).label('total_amount'),
+        )
+        .join(Accrual, Payment.accrual_id == Accrual.accrual_id)
+        .join(TaxType, TaxType.tax_type_id == Accrual.tax_type_id)
+        .group_by(Accrual.tax_type_id, TaxType.tax_name)
+    )
+    rows = result.all()
+    return [
+        {
+            'tax_type_id': r.tax_type_id,
+            'tax_name': r.tax_name,
+            'total_amount': r.total_amount,
+        }
+        for r in rows
+    ]
+
+
+async def debtors_list(db: AsyncSession) -> List[Dict]:
+    # Update debts for all taxpayers
+    taxpayer_ids = (await db.execute(select(Taxpayer.taxpayer_id))).scalars().all()
+    for tid in taxpayer_ids:
+        await calculate_debts(db, tid)
+
+    result = await db.execute(
+        select(
+            Taxpayer.taxpayer_id,
+            Taxpayer.last_name,
+            Taxpayer.first_name,
+            Taxpayer.middle_name,
+            Taxpayer.company_name,
+            func.sum(Debt.principal_amount + Debt.penalty_amount).label('total_debt'),
+        )
+        .join(Accrual, Accrual.taxpayer_id == Taxpayer.taxpayer_id)
+        .join(Debt, Debt.accrual_id == Accrual.accrual_id)
+        .where(Debt.status == 'активно')
+        .group_by(
+            Taxpayer.taxpayer_id,
+            Taxpayer.last_name,
+            Taxpayer.first_name,
+            Taxpayer.middle_name,
+            Taxpayer.company_name,
+        )
+    )
+    rows = result.all()
+
+    def build_name(row):
+        if row.company_name:
+            return row.company_name
+        parts = [row.last_name, row.first_name, row.middle_name]
+        return ' '.join([p for p in parts if p])
+
+    return [
+        {
+            'taxpayer_id': r.taxpayer_id,
+            'name': build_name(r),
+            'total_debt': r.total_debt,
+        }
+        for r in rows
+    ]

--- a/app/routes/__init__.py
+++ b/app/routes/__init__.py
@@ -1,5 +1,5 @@
 from fastapi import APIRouter
-from . import taxpayers, declarations, payments, debts, inspections
+from . import taxpayers, declarations, payments, debts, inspections, reports
 
 api_router = APIRouter()
 api_router.include_router(taxpayers.router, prefix='/taxpayers', tags=['Taxpayers'])
@@ -7,5 +7,6 @@ api_router.include_router(declarations.router, prefix='/declarations', tags=['De
 api_router.include_router(payments.router, prefix='/payments', tags=['Payments'])
 api_router.include_router(debts.router, prefix='/debts', tags=['Debts'])
 api_router.include_router(inspections.router, prefix='/inspections', tags=['Inspections'])
+api_router.include_router(reports.router, prefix='/reports', tags=['Reports'])
 
 __all__ = ['api_router']

--- a/app/routes/reports.py
+++ b/app/routes/reports.py
@@ -1,0 +1,20 @@
+from typing import List
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.database import get_session
+from app.crud import tax_revenue_report, debtors_list
+from app.schemas import TaxRevenueItem, DebtorItem
+
+router = APIRouter()
+
+
+@router.get('/payments', response_model=List[TaxRevenueItem])
+async def payments_report(db: AsyncSession = Depends(get_session)):
+    return await tax_revenue_report(db)
+
+
+@router.get('/debtors', response_model=List[DebtorItem])
+async def debtors_report(db: AsyncSession = Depends(get_session)):
+    return await debtors_list(db)

--- a/app/schemas/__init__.py
+++ b/app/schemas/__init__.py
@@ -4,6 +4,7 @@ from .payment import PaymentCreate, PaymentRead
 from .accrual import AccrualRead
 from .debt import DebtRead
 from .inspection import InspectionCreate, InspectionRead
+from .report import TaxRevenueItem, DebtorItem
 
 __all__ = [
     'TaxpayerCreate',
@@ -17,4 +18,6 @@ __all__ = [
     'DebtRead',
     'InspectionCreate',
     'InspectionRead',
+    'TaxRevenueItem',
+    'DebtorItem',
 ]

--- a/app/schemas/report.py
+++ b/app/schemas/report.py
@@ -1,0 +1,14 @@
+from decimal import Decimal
+from pydantic import BaseModel
+
+
+class TaxRevenueItem(BaseModel):
+    tax_type_id: str
+    tax_name: str
+    total_amount: Decimal
+
+
+class DebtorItem(BaseModel):
+    taxpayer_id: str
+    name: str
+    total_debt: Decimal


### PR DESCRIPTION
## Summary
- add API for tax revenue and debtors reports
- expose new report CRUD utilities and schemas
- register report endpoints in the router

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850df9e3a80832c8fecfe1b618c5dec