### PR TITLE
Implement report PDF/Excel and data backup

### DIFF
--- a/app/routes/__init__.py
+++ b/app/routes/__init__.py
@@ -1,5 +1,5 @@
 from fastapi import APIRouter
-from . import taxpayers, declarations, payments, debts, inspections, reports
+from . import taxpayers, declarations, payments, debts, inspections, reports, backup
 
 api_router = APIRouter()
 api_router.include_router(taxpayers.router, prefix='/taxpayers', tags=['Taxpayers'])
@@ -8,5 +8,6 @@ api_router.include_router(payments.router, prefix='/payments', tags=['Payments']
 api_router.include_router(debts.router, prefix='/debts', tags=['Debts'])
 api_router.include_router(inspections.router, prefix='/inspections', tags=['Inspections'])
 api_router.include_router(reports.router, prefix='/reports', tags=['Reports'])
+api_router.include_router(backup.router, prefix='/backup', tags=['Backup'])
 
 __all__ = ['api_router']

--- a/app/routes/backup.py
+++ b/app/routes/backup.py
@@ -1,0 +1,74 @@
+from fastapi import APIRouter, Depends, UploadFile, File
+from fastapi.responses import Response
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.database import get_session
+from app.utils.backup import (
+    export_table_csv,
+    import_table_csv,
+    export_sql_dump,
+    import_sql_dump,
+)
+from app.models import Taxpayer, Payment, TaxDeclaration, Accrual, Debt, Inspection
+
+router = APIRouter()
+
+
+@router.post('/export/csv/{table_name}')
+async def export_csv(table_name: str, db: AsyncSession = Depends(get_session)):
+    model = {
+        'taxpayer': Taxpayer,
+        'payment': Payment,
+        'declaration': TaxDeclaration,
+        'accrual': Accrual,
+        'debt': Debt,
+        'inspection': Inspection,
+    }.get(table_name)
+    if not model:
+        return Response(status_code=400)
+    path = f'exports/{table_name}.csv'
+    await export_table_csv(db, model, path)
+    with open(path, 'rb') as f:
+        data = f.read()
+    return Response(data, media_type='text/csv')
+
+
+@router.post('/import/csv/{table_name}')
+async def import_csv_endpoint(
+    table_name: str,
+    file: UploadFile = File(...),
+    db: AsyncSession = Depends(get_session),
+):
+    model = {
+        'taxpayer': Taxpayer,
+        'payment': Payment,
+        'declaration': TaxDeclaration,
+        'accrual': Accrual,
+        'debt': Debt,
+        'inspection': Inspection,
+    }.get(table_name)
+    if not model:
+        return Response(status_code=400)
+    path = f'exports/{table_name}.csv'
+    with open(path, 'wb') as f:
+        f.write(await file.read())
+    await import_table_csv(db, model, path)
+    return {'status': 'ok'}
+
+
+@router.post('/export/sql')
+async def export_sql():
+    path = 'exports/dump.sql'
+    export_sql_dump(path)
+    with open(path, 'rb') as f:
+        data = f.read()
+    return Response(data, media_type='application/sql')
+
+
+@router.post('/import/sql')
+async def import_sql(file: UploadFile = File(...)):
+    path = 'exports/upload.sql'
+    with open(path, 'wb') as f:
+        f.write(await file.read())
+    import_sql_dump(path)
+    return {'status': 'ok'}

--- a/app/routes/reports.py
+++ b/app/routes/reports.py
@@ -1,11 +1,13 @@
 from typing import List
 
 from fastapi import APIRouter, Depends
+from fastapi.responses import Response
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.database import get_session
 from app.crud import tax_revenue_report, debtors_list
 from app.schemas import TaxRevenueItem, DebtorItem
+from app.utils.reporting import generate_pdf, generate_excel
 
 router = APIRouter()
 
@@ -15,6 +17,34 @@ async def payments_report(db: AsyncSession = Depends(get_session)):
     return await tax_revenue_report(db)
 
 
+@router.get('/payments/pdf')
+async def payments_report_pdf(db: AsyncSession = Depends(get_session)):
+    data = await tax_revenue_report(db)
+    pdf_bytes = generate_pdf(data, 'Tax Revenue Report')
+    return Response(pdf_bytes, media_type='application/pdf')
+
+
+@router.get('/payments/excel')
+async def payments_report_excel(db: AsyncSession = Depends(get_session)):
+    data = await tax_revenue_report(db)
+    xls_bytes = generate_excel(data, 'Tax Revenue Report')
+    return Response(xls_bytes, media_type='application/vnd.openxmlformats-officedocument.spreadsheetml.sheet')
+
+
 @router.get('/debtors', response_model=List[DebtorItem])
 async def debtors_report(db: AsyncSession = Depends(get_session)):
     return await debtors_list(db)
+
+
+@router.get('/debtors/pdf')
+async def debtors_report_pdf(db: AsyncSession = Depends(get_session)):
+    data = await debtors_list(db)
+    pdf_bytes = generate_pdf(data, 'Debtors List')
+    return Response(pdf_bytes, media_type='application/pdf')
+
+
+@router.get('/debtors/excel')
+async def debtors_report_excel(db: AsyncSession = Depends(get_session)):
+    data = await debtors_list(db)
+    xls_bytes = generate_excel(data, 'Debtors List')
+    return Response(xls_bytes, media_type='application/vnd.openxmlformats-officedocument.spreadsheetml.sheet')

--- a/app/utils/backup.py
+++ b/app/utils/backup.py
@@ -1,0 +1,44 @@
+import os
+import pandas as pd
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select
+from app.core.database import Base, engine
+
+async def export_table_csv(db: AsyncSession, model, path: str) -> None:
+    result = await db.execute(select(model))
+    rows = result.scalars().all()
+    df = pd.DataFrame([r.__dict__ for r in rows])
+    df.pop('_sa_instance_state', None)
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    df.to_csv(path, index=False)
+
+async def import_table_csv(db: AsyncSession, model, path: str) -> None:
+    df = pd.read_csv(path)
+    for _, row in df.iterrows():
+        obj = model(**row.to_dict())
+        db.merge(obj)
+    await db.commit()
+
+
+def export_sql_dump(path: str) -> None:
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    db_user = os.getenv('DB_USER')
+    db_pass = os.getenv('DB_PASSWORD')
+    db_host = os.getenv('DB_HOST')
+    db_port = os.getenv('DB_PORT')
+    db_name = os.getenv('DB_NAME')
+    dump_cmd = (
+        f"mysqldump -h {db_host} -P {db_port} -u {db_user} -p{db_pass} {db_name} > {path}"
+    )
+    os.system(dump_cmd)
+
+
+def import_sql_dump(path: str) -> None:
+    db_user = os.getenv('DB_USER')
+    db_pass = os.getenv('DB_PASSWORD')
+    db_host = os.getenv('DB_HOST')
+    db_port = os.getenv('DB_PORT')
+    db_name = os.getenv('DB_NAME')
+    cmd = f"mysql -h {db_host} -P {db_port} -u {db_user} -p{db_pass} {db_name} < {path}"
+    os.system(cmd)
+

--- a/app/utils/reporting.py
+++ b/app/utils/reporting.py
@@ -1,0 +1,36 @@
+from typing import List, Dict
+from io import BytesIO
+from weasyprint import HTML
+from openpyxl import Workbook
+
+
+def generate_pdf(data: List[Dict], title: str) -> bytes:
+    """Generate simple PDF report from list of dicts."""
+    headers = list(data[0].keys()) if data else []
+    rows = "".join(
+        "<tr>" + "".join(f"<td>{item[h]}</td>" for h in headers) + "</tr>"
+        for item in data
+    )
+    header_row = "".join(f"<th>{h}</th>" for h in headers)
+    html = f"""
+    <h1>{title}</h1>
+    <table border='1' cellspacing='0' cellpadding='4'>
+        <thead><tr>{header_row}</tr></thead>
+        <tbody>{rows}</tbody>
+    </table>
+    """
+    return HTML(string=html).write_pdf()
+
+
+def generate_excel(data: List[Dict], sheet_name: str = "Sheet1") -> bytes:
+    """Generate Excel report from list of dicts."""
+    wb = Workbook()
+    ws = wb.active
+    ws.title = sheet_name
+    if data:
+        ws.append(list(data[0].keys()))
+    for item in data:
+        ws.append(list(item.values()))
+    bio = BytesIO()
+    wb.save(bio)
+    return bio.getvalue()


### PR DESCRIPTION
## Summary
- add PDF and Excel helpers
- provide endpoints for PDF/Excel reports
- support CSV and SQL dump export/import
- wire new backup router

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6850e1882008832ca2ee269c8fe5ef43