### PR TITLE
Add simple Bootstrap UI served by backend

### DIFF
--- a/app/static/index.html
+++ b/app/static/index.html
@@ -1,0 +1,55 @@
+<!doctype html>
+<html lang="ru">
+<head>
+  <meta charset="UTF-8">
+  <title>Tax Service API UI</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body class="p-4">
+  <div class="container">
+    <h1 class="mb-4">Tax Service API UI</h1>
+    <form id="api-form" class="mb-4">
+      <div class="mb-3">
+        <label for="method" class="form-label">Method</label>
+        <select id="method" class="form-select">
+          <option>GET</option>
+          <option>POST</option>
+          <option>PUT</option>
+          <option>DELETE</option>
+        </select>
+      </div>
+      <div class="mb-3">
+        <label for="endpoint" class="form-label">Endpoint</label>
+        <input type="text" class="form-control" id="endpoint" placeholder="/taxpayers/123">
+      </div>
+      <div class="mb-3">
+        <label for="body" class="form-label">JSON Body</label>
+        <textarea id="body" class="form-control" rows="4"></textarea>
+      </div>
+      <button type="submit" class="btn btn-primary">Send</button>
+    </form>
+    <h5>Response</h5>
+    <pre id="response" class="bg-light p-3 border"></pre>
+  </div>
+<script>
+document.getElementById('api-form').addEventListener('submit', async function(e) {
+  e.preventDefault();
+  const method = document.getElementById('method').value;
+  const endpoint = document.getElementById('endpoint').value;
+  let bodyText = document.getElementById('body').value.trim();
+  let body = undefined;
+  if (bodyText) {
+    try { body = JSON.parse(bodyText); }
+    catch (err) { alert('Invalid JSON body'); return; }
+  }
+  const res = await fetch(endpoint, {
+    method,
+    headers: {'Content-Type': 'application/json'},
+    body: body ? JSON.stringify(body) : undefined
+  });
+  const text = await res.text();
+  document.getElementById('response').textContent = text;
+});
+</script>
+</body>
+</html>

--- a/main.py
+++ b/main.py
@@ -1,8 +1,18 @@
 # main.py
 from fastapi import FastAPI
+from fastapi.responses import FileResponse, HTMLResponse
+from fastapi.staticfiles import StaticFiles
 from app.routes import api_router
 
 app = FastAPI(title="АИС «Налог‑Учёт»")
+
+# Serve static UI
+app.mount("/static", StaticFiles(directory="app/static"), name="static")
+
+@app.get("/", response_class=HTMLResponse)
+async def ui_index():
+    """Serve the simple Bootstrap-based UI."""
+    return FileResponse("app/static/index.html")
 
 # Register routers
 app.include_router(api_router)


### PR DESCRIPTION
## Summary
- serve a minimal UI via FastAPI that uses Bootstrap from CDN
- add HTML page with a form to call API endpoints

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850e2b34cf0832c9d179ad6f397484f