### PR TITLE
Add simple web UI for taxpayers

### DIFF
--- a/app/routes/__init__.py
+++ b/app/routes/__init__.py
@@ -1,13 +1,27 @@
 from fastapi import APIRouter
-from . import taxpayers, declarations, payments, debts, inspections, reports, backup
+from . import (
+    taxpayers,
+    declarations,
+    payments,
+    debts,
+    inspections,
+    reports,
+    backup,
+    web,
+)
 
 api_router = APIRouter()
-api_router.include_router(taxpayers.router, prefix='/taxpayers', tags=['Taxpayers'])
-api_router.include_router(declarations.router, prefix='/declarations', tags=['Declarations'])
-api_router.include_router(payments.router, prefix='/payments', tags=['Payments'])
-api_router.include_router(debts.router, prefix='/debts', tags=['Debts'])
-api_router.include_router(inspections.router, prefix='/inspections', tags=['Inspections'])
-api_router.include_router(reports.router, prefix='/reports', tags=['Reports'])
-api_router.include_router(backup.router, prefix='/backup', tags=['Backup'])
+api_router.include_router(taxpayers.router, prefix="/taxpayers", tags=["Taxpayers"])
+api_router.include_router(
+    declarations.router, prefix="/declarations", tags=["Declarations"]
+)
+api_router.include_router(payments.router, prefix="/payments", tags=["Payments"])
+api_router.include_router(debts.router, prefix="/debts", tags=["Debts"])
+api_router.include_router(
+    inspections.router, prefix="/inspections", tags=["Inspections"]
+)
+api_router.include_router(reports.router, prefix="/reports", tags=["Reports"])
+api_router.include_router(backup.router, prefix="/backup", tags=["Backup"])
+api_router.include_router(web.router, prefix="", tags=["Web"])
 
-__all__ = ['api_router']
+__all__ = ["api_router"]

--- a/app/templates/declarations/form.html
+++ b/app/templates/declarations/form.html
@@ -1,0 +1,25 @@
+{% extends 'layout.html' %}
+{% block title %}Новая декларация{% endblock %}
+{% block content %}
+<h3>Новая декларация для {{ taxpayer.taxpayer_id }}</h3>
+<form method="post">
+  <input type="hidden" name="taxpayer_id" value="{{ taxpayer.taxpayer_id }}">
+  <div class="mb-3">
+    <label class="form-label">Вид налога</label>
+    <input type="text" name="tax_type_id" class="form-control" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Период (год)</label>
+    <input type="number" name="period" class="form-control" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Дата подачи</label>
+    <input type="date" name="submission_date" class="form-control" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Сумма</label>
+    <input type="number" step="0.01" name="declared_tax_amount" class="form-control" required>
+  </div>
+  <button type="submit" class="btn btn-primary">Создать</button>
+</form>
+{% endblock %}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,0 +1,4 @@
+{% extends 'layout.html' %}
+{% block content %}
+<a href="{{ url_for('web.list_taxpayers') }}" class="btn btn-primary">Налогоплательщики</a>
+{% endblock %}

--- a/app/templates/layout.html
+++ b/app/templates/layout.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="ru">
+<head>
+  <meta charset="utf-8">
+  <title>{% block title %}Налог-Учёт{% endblock %}</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body class="p-4">
+<div class="container">
+  <h1 class="mb-4">Налог‑Учёт</h1>
+  {% block content %}{% endblock %}
+</div>
+</body>
+</html>

--- a/app/templates/taxpayers/form.html
+++ b/app/templates/taxpayers/form.html
@@ -1,0 +1,31 @@
+{% extends 'layout.html' %}
+{% block title %}{{ 'Новый налогоплательщик' if new else 'Налогоплательщик' }}{% endblock %}
+{% block content %}
+<form method="post">
+  <div class="mb-3">
+    <label class="form-label">ИНН</label>
+    <input type="text" name="taxpayer_id" class="form-control" value="{{ taxpayer.taxpayer_id or '' }}" {% if not new %}readonly{% endif %}>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Тип (F/U)</label>
+    <input type="text" name="type" class="form-control" value="{{ taxpayer.type or '' }}">
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Фамилия</label>
+    <input type="text" name="last_name" class="form-control" value="{{ taxpayer.last_name or '' }}">
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Имя</label>
+    <input type="text" name="first_name" class="form-control" value="{{ taxpayer.first_name or '' }}">
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Отчество</label>
+    <input type="text" name="middle_name" class="form-control" value="{{ taxpayer.middle_name or '' }}">
+  </div>
+  <button type="submit" class="btn btn-primary">Сохранить</button>
+</form>
+{% if not new %}
+<hr>
+<a href="{{ url_for('web.add_declaration', taxpayer_id=taxpayer.taxpayer_id) }}" class="btn btn-outline-primary">Новая декларация</a>
+{% endif %}
+{% endblock %}

--- a/app/templates/taxpayers/list.html
+++ b/app/templates/taxpayers/list.html
@@ -1,0 +1,33 @@
+{% extends 'layout.html' %}
+{% block title %}Налогоплательщики{% endblock %}
+{% block content %}
+<form method="get" class="mb-3">
+  <div class="input-group">
+    <input type="text" name="query" class="form-control" placeholder="ИНН или ФИО" value="{{ query or '' }}">
+    <button type="submit" class="btn btn-outline-primary">Поиск</button>
+    <a href="{{ url_for('web.new_taxpayer') }}" class="btn btn-primary ms-2">Добавить</a>
+  </div>
+</form>
+{% if taxpayers %}
+<table class="table table-bordered">
+  <thead>
+    <tr>
+      <th>ИНН</th>
+      <th>ФИО / Компания</th>
+      <th></th>
+    </tr>
+  </thead>
+  <tbody>
+  {% for tp in taxpayers %}
+    <tr>
+      <td>{{ tp.taxpayer_id }}</td>
+      <td>{{ tp.last_name or tp.company_name }} {{ tp.first_name or '' }} {{ tp.middle_name or '' }}</td>
+      <td><a href="{{ url_for('web.edit_taxpayer', taxpayer_id=tp.taxpayer_id) }}" class="btn btn-sm btn-secondary">Открыть</a></td>
+    </tr>
+  {% endfor %}
+  </tbody>
+</table>
+{% else %}
+<p>Ничего не найдено</p>
+{% endif %}
+{% endblock %}

--- a/main.py
+++ b/main.py
@@ -1,18 +1,12 @@
 # main.py
 from fastapi import FastAPI
-from fastapi.responses import FileResponse, HTMLResponse
 from fastapi.staticfiles import StaticFiles
 from app.routes import api_router
 
 app = FastAPI(title="АИС «Налог‑Учёт»")
 
-# Serve static UI
+# Serve static files
 app.mount("/static", StaticFiles(directory="app/static"), name="static")
-
-@app.get("/", response_class=HTMLResponse)
-async def ui_index():
-    """Serve the simple Bootstrap-based UI."""
-    return FileResponse("app/static/index.html")
 
 # Register routers
 app.include_router(api_router)

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ pydantic
 weasyprint
 openpyxl
 pandas
+jinja2


### PR DESCRIPTION
## Summary
- include jinja2 in requirements
- add new UI templates with Bootstrap
- implement `web` router with search/edit forms for taxpayers and declarations
- hook web router into app
- remove old static root handler

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850e524251c832cba2f976363d6ed79