### PR TITLE
Add navigation and paginated taxpayers table

### DIFF
--- a/app/crud/__init__.py
+++ b/app/crud/__init__.py
@@ -1,6 +1,7 @@
 from .taxpayer import (
     get_taxpayer,
     search_taxpayers,
+    count_taxpayers,
     create_taxpayer,
     update_taxpayer,
 )
@@ -13,6 +14,7 @@ from .report import tax_revenue_report, debtors_list
 __all__ = [
     'get_taxpayer',
     'search_taxpayers',
+    'count_taxpayers',
     'create_taxpayer',
     'update_taxpayer',
     'get_declaration',

--- a/app/crud/taxpayer.py
+++ b/app/crud/taxpayer.py
@@ -1,5 +1,6 @@
 from typing import List, Optional
 from sqlalchemy.future import select
+from sqlalchemy import func
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.taxpayer import Taxpayer
@@ -10,19 +11,42 @@ async def get_taxpayer(db: AsyncSession, taxpayer_id: str) -> Optional[Taxpayer]
     return result.scalar_one_or_none()
 
 
-async def search_taxpayers(db: AsyncSession, query: str) -> List[Taxpayer]:
+async def search_taxpayers(
+    db: AsyncSession,
+    query: str,
+    limit: int = 20,
+    offset: int = 0,
+) -> List[Taxpayer]:
+    """Search taxpayers with optional pagination."""
     stmt = select(Taxpayer)
     if query:
         like_pattern = f"%{query}%"
         stmt = stmt.where(
-            (Taxpayer.taxpayer_id == query) |
-            (Taxpayer.last_name.ilike(like_pattern)) |
-            (Taxpayer.first_name.ilike(like_pattern)) |
-            (Taxpayer.middle_name.ilike(like_pattern)) |
-            (Taxpayer.company_name.ilike(like_pattern))
+            (Taxpayer.taxpayer_id == query)
+            | (Taxpayer.last_name.ilike(like_pattern))
+            | (Taxpayer.first_name.ilike(like_pattern))
+            | (Taxpayer.middle_name.ilike(like_pattern))
+            | (Taxpayer.company_name.ilike(like_pattern))
         )
+    stmt = stmt.order_by(Taxpayer.taxpayer_id).offset(offset).limit(limit)
     result = await db.execute(stmt)
     return result.scalars().all()
+
+
+async def count_taxpayers(db: AsyncSession, query: str) -> int:
+    """Return number of taxpayers matching the query."""
+    stmt = select(func.count()).select_from(Taxpayer)
+    if query:
+        like_pattern = f"%{query}%"
+        stmt = stmt.where(
+            (Taxpayer.taxpayer_id == query)
+            | (Taxpayer.last_name.ilike(like_pattern))
+            | (Taxpayer.first_name.ilike(like_pattern))
+            | (Taxpayer.middle_name.ilike(like_pattern))
+            | (Taxpayer.company_name.ilike(like_pattern))
+        )
+    result = await db.execute(stmt)
+    return result.scalar_one()
 
 
 async def create_taxpayer(db: AsyncSession, data: dict) -> Taxpayer:

--- a/app/routes/taxpayers.py
+++ b/app/routes/taxpayers.py
@@ -6,6 +6,7 @@ from app.core.database import get_session
 from app.crud import (
     get_taxpayer,
     search_taxpayers,
+    count_taxpayers,
     create_taxpayer,
     update_taxpayer,
 )
@@ -15,8 +16,14 @@ router = APIRouter()
 
 
 @router.get('/search', response_model=List[TaxpayerRead])
-async def search(query: str, db: AsyncSession = Depends(get_session)):
-    return await search_taxpayers(db, query)
+async def search(
+    query: str,
+    page: int = 1,
+    limit: int = 20,
+    db: AsyncSession = Depends(get_session),
+):
+    offset = (page - 1) * limit
+    return await search_taxpayers(db, query, limit=limit, offset=offset)
 
 
 @router.get('/{taxpayer_id}', response_model=TaxpayerRead)

--- a/app/templates/layout.html
+++ b/app/templates/layout.html
@@ -5,9 +5,32 @@
   <title>{% block title %}Налог-Учёт{% endblock %}</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/css/bootstrap.min.css" rel="stylesheet">
 </head>
-<body class="p-4">
+<body>
+<nav class="navbar navbar-expand-lg navbar-light bg-light mb-4">
+  <div class="container-fluid">
+    <a class="navbar-brand" href="{{ url_for('web.list_taxpayers') }}">Налог‑Учёт</a>
+    <div class="collapse navbar-collapse">
+      <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+        <li class="nav-item">
+          <a class="nav-link {% if active_tab=='taxpayers' %}active{% endif %}" href="{{ url_for('web.list_taxpayers') }}">Налогоплательщики</a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link {% if active_tab=='declarations' %}active{% endif %}" href="#">Декларации</a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link {% if active_tab=='payments' %}active{% endif %}" href="#">Платежи</a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link {% if active_tab=='reports' %}active{% endif %}" href="#">Отчёты</a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link {% if active_tab=='export' %}active{% endif %}" href="#">Экспорт</a>
+        </li>
+      </ul>
+    </div>
+  </div>
+</nav>
 <div class="container">
-  <h1 class="mb-4">Налог‑Учёт</h1>
   {% block content %}{% endblock %}
 </div>
 </body>

--- a/app/templates/taxpayers/list.html
+++ b/app/templates/taxpayers/list.html
@@ -7,6 +7,7 @@
     <button type="submit" class="btn btn-outline-primary">Поиск</button>
     <a href="{{ url_for('web.new_taxpayer') }}" class="btn btn-primary ms-2">Добавить</a>
   </div>
+  <input type="hidden" name="page" value="1">
 </form>
 {% if taxpayers %}
 <table class="table table-bordered">
@@ -27,6 +28,23 @@
   {% endfor %}
   </tbody>
 </table>
+  {% if pages > 1 %}
+  <nav>
+    <ul class="pagination">
+      <li class="page-item {% if page <= 1 %}disabled{% endif %}">
+        <a class="page-link" href="?query={{ query }}&page={{ page - 1 }}">&laquo;</a>
+      </li>
+      {% for p in range(1, pages + 1) %}
+      <li class="page-item {% if p == page %}active{% endif %}">
+        <a class="page-link" href="?query={{ query }}&page={{ p }}">{{ p }}</a>
+      </li>
+      {% endfor %}
+      <li class="page-item {% if page >= pages %}disabled{% endif %}">
+        <a class="page-link" href="?query={{ query }}&page={{ page + 1 }}">&raquo;</a>
+      </li>
+    </ul>
+  </nav>
+  {% endif %}
 {% else %}
 <p>Ничего не найдено</p>
 {% endif %}


### PR DESCRIPTION
## Summary
- add count_taxpayers and pagination support in CRUD and API
- redirect index to taxpayer list and highlight active menu tab
- create Bootstrap navbar with all sections
- show taxpayers table with pagination controls

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850e786d054832c9a205de99c56e244