### PR TITLE
Add taxpayer debt column with modal details

### DIFF
--- a/app/crud/__init__.py
+++ b/app/crud/__init__.py
@@ -1,18 +1,20 @@
 from .taxpayer import (
     get_taxpayer,
     search_taxpayers,
+    count_taxpayers,
     create_taxpayer,
     update_taxpayer,
 )
 from .declaration import get_declaration, create_declaration
 from .payment import get_payment, create_payment
-from .debt import calculate_debts
+from .debt import calculate_debts, total_debt
 from .inspection import get_inspection, list_inspections, create_inspection
 from .report import tax_revenue_report, debtors_list
 
 __all__ = [
     'get_taxpayer',
     'search_taxpayers',
+    'count_taxpayers',
     'create_taxpayer',
     'update_taxpayer',
     'get_declaration',
@@ -20,6 +22,7 @@ __all__ = [
     'get_payment',
     'create_payment',
     'calculate_debts',
+    'total_debt',
     'get_inspection',
     'list_inspections',
     'create_inspection',

--- a/app/crud/taxpayer.py
+++ b/app/crud/taxpayer.py
@@ -1,5 +1,6 @@
 from typing import List, Optional
 from sqlalchemy.future import select
+from sqlalchemy import func
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.taxpayer import Taxpayer
@@ -10,19 +11,42 @@ async def get_taxpayer(db: AsyncSession, taxpayer_id: str) -> Optional[Taxpayer]
     return result.scalar_one_or_none()
 
 
-async def search_taxpayers(db: AsyncSession, query: str) -> List[Taxpayer]:
+async def search_taxpayers(
+    db: AsyncSession,
+    query: str,
+    limit: int = 20,
+    offset: int = 0,
+) -> List[Taxpayer]:
+    """Search taxpayers with optional pagination."""
     stmt = select(Taxpayer)
     if query:
         like_pattern = f"%{query}%"
         stmt = stmt.where(
-            (Taxpayer.taxpayer_id == query) |
-            (Taxpayer.last_name.ilike(like_pattern)) |
-            (Taxpayer.first_name.ilike(like_pattern)) |
-            (Taxpayer.middle_name.ilike(like_pattern)) |
-            (Taxpayer.company_name.ilike(like_pattern))
+            (Taxpayer.taxpayer_id == query)
+            | (Taxpayer.last_name.ilike(like_pattern))
+            | (Taxpayer.first_name.ilike(like_pattern))
+            | (Taxpayer.middle_name.ilike(like_pattern))
+            | (Taxpayer.company_name.ilike(like_pattern))
         )
+    stmt = stmt.order_by(Taxpayer.taxpayer_id).offset(offset).limit(limit)
     result = await db.execute(stmt)
     return result.scalars().all()
+
+
+async def count_taxpayers(db: AsyncSession, query: str) -> int:
+    """Return number of taxpayers matching the query."""
+    stmt = select(func.count()).select_from(Taxpayer)
+    if query:
+        like_pattern = f"%{query}%"
+        stmt = stmt.where(
+            (Taxpayer.taxpayer_id == query)
+            | (Taxpayer.last_name.ilike(like_pattern))
+            | (Taxpayer.first_name.ilike(like_pattern))
+            | (Taxpayer.middle_name.ilike(like_pattern))
+            | (Taxpayer.company_name.ilike(like_pattern))
+        )
+    result = await db.execute(stmt)
+    return result.scalar_one()
 
 
 async def create_taxpayer(db: AsyncSession, data: dict) -> Taxpayer:

--- a/app/routes/taxpayers.py
+++ b/app/routes/taxpayers.py
@@ -6,6 +6,7 @@ from app.core.database import get_session
 from app.crud import (
     get_taxpayer,
     search_taxpayers,
+    count_taxpayers,
     create_taxpayer,
     update_taxpayer,
 )
@@ -15,8 +16,14 @@ router = APIRouter()
 
 
 @router.get('/search', response_model=List[TaxpayerRead])
-async def search(query: str, db: AsyncSession = Depends(get_session)):
-    return await search_taxpayers(db, query)
+async def search(
+    query: str,
+    page: int = 1,
+    limit: int = 20,
+    db: AsyncSession = Depends(get_session),
+):
+    offset = (page - 1) * limit
+    return await search_taxpayers(db, query, limit=limit, offset=offset)
 
 
 @router.get('/{taxpayer_id}', response_model=TaxpayerRead)

--- a/app/routes/web.py
+++ b/app/routes/web.py
@@ -7,6 +7,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.database import get_session
 from app.crud import (
     search_taxpayers,
+    count_taxpayers,
+    total_debt,
     get_taxpayer,
     create_taxpayer as crud_create_taxpayer,
     update_taxpayer as crud_update_taxpayer,
@@ -20,24 +22,49 @@ router = APIRouter()
 
 @router.get("/", name="web.index")
 async def index(request: Request):
-    return templates.TemplateResponse("index.html", {"request": request})
+    url = router.url_path_for("web.list_taxpayers")
+    return RedirectResponse(url)
 
 
 @router.get("/taxpayers", name="web.list_taxpayers")
 async def list_taxpayers(
-    request: Request, query: str = "", db: AsyncSession = Depends(get_session)
+    request: Request,
+    query: str = "",
+    page: int = 1,
+    db: AsyncSession = Depends(get_session),
 ):
-    taxpayers = await search_taxpayers(db, query) if query else []
+    limit = 20
+    offset = (page - 1) * limit
+    total = await count_taxpayers(db, query)
+    taxpayers = await search_taxpayers(db, query, limit=limit, offset=offset)
+    debts = {}
+    for tp in taxpayers:
+        debts[tp.taxpayer_id] = await total_debt(db, tp.taxpayer_id)
+    pages = (total + limit - 1) // limit
     return templates.TemplateResponse(
         "taxpayers/list.html",
-        {"request": request, "taxpayers": taxpayers, "query": query},
+        {
+            "request": request,
+            "taxpayers": taxpayers,
+            "debts": debts,
+            "query": query,
+            "page": page,
+            "pages": pages,
+            "active_tab": "taxpayers",
+        },
     )
 
 
 @router.get("/taxpayers/new", name="web.new_taxpayer")
 async def new_taxpayer_form(request: Request):
     return templates.TemplateResponse(
-        "taxpayers/form.html", {"request": request, "taxpayer": {}, "new": True}
+        "taxpayers/form.html",
+        {
+            "request": request,
+            "taxpayer": {},
+            "new": True,
+            "active_tab": "taxpayers",
+        },
     )
 
 
@@ -71,7 +98,13 @@ async def edit_taxpayer(
     if not tp:
         raise HTTPException(status_code=404, detail="Taxpayer not found")
     return templates.TemplateResponse(
-        "taxpayers/form.html", {"request": request, "taxpayer": tp, "new": False}
+        "taxpayers/form.html",
+        {
+            "request": request,
+            "taxpayer": tp,
+            "new": False,
+            "active_tab": "taxpayers",
+        },
     )
 
 
@@ -103,7 +136,11 @@ async def update_taxpayer(
 async def new_declaration_form(request: Request, taxpayer_id: str):
     return templates.TemplateResponse(
         "declarations/form.html",
-        {"request": request, "taxpayer": {"taxpayer_id": taxpayer_id}},
+        {
+            "request": request,
+            "taxpayer": {"taxpayer_id": taxpayer_id},
+            "active_tab": "declarations",
+        },
     )
 
 

--- a/app/templates/layout.html
+++ b/app/templates/layout.html
@@ -5,9 +5,32 @@
   <title>{% block title %}Налог-Учёт{% endblock %}</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/css/bootstrap.min.css" rel="stylesheet">
 </head>
-<body class="p-4">
+<body>
+<nav class="navbar navbar-expand-lg navbar-light bg-light mb-4">
+  <div class="container">
+    <a class="navbar-brand" href="{{ url_for('web.list_taxpayers') }}">Налог‑Учёт</a>
+    <div class="collapse navbar-collapse">
+      <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+        <li class="nav-item">
+          <a class="nav-link {% if active_tab=='taxpayers' %}active{% endif %}" href="{{ url_for('web.list_taxpayers') }}">Налогоплательщики</a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link {% if active_tab=='declarations' %}active{% endif %}" href="#">Декларации</a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link {% if active_tab=='payments' %}active{% endif %}" href="#">Платежи</a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link {% if active_tab=='reports' %}active{% endif %}" href="#">Отчёты</a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link {% if active_tab=='export' %}active{% endif %}" href="#">Экспорт</a>
+        </li>
+      </ul>
+    </div>
+  </div>
+</nav>
 <div class="container">
-  <h1 class="mb-4">Налог‑Учёт</h1>
   {% block content %}{% endblock %}
 </div>
 </body>

--- a/app/templates/taxpayers/list.html
+++ b/app/templates/taxpayers/list.html
@@ -7,6 +7,7 @@
     <button type="submit" class="btn btn-outline-primary">Поиск</button>
     <a href="{{ url_for('web.new_taxpayer') }}" class="btn btn-primary ms-2">Добавить</a>
   </div>
+  <input type="hidden" name="page" value="1">
 </form>
 {% if taxpayers %}
 <table class="table table-bordered">
@@ -14,6 +15,7 @@
     <tr>
       <th>ИНН</th>
       <th>ФИО / Компания</th>
+      <th>Задолженность</th>
       <th></th>
     </tr>
   </thead>
@@ -22,12 +24,68 @@
     <tr>
       <td>{{ tp.taxpayer_id }}</td>
       <td>{{ tp.last_name or tp.company_name }} {{ tp.first_name or '' }} {{ tp.middle_name or '' }}</td>
-      <td><a href="{{ url_for('web.edit_taxpayer', taxpayer_id=tp.taxpayer_id) }}" class="btn btn-sm btn-secondary">Открыть</a></td>
+      <td>{{ debts[tp.taxpayer_id]|round(2) }}</td>
+      <td><button type="button" class="btn btn-sm btn-secondary" onclick="openTaxpayer('{{ tp.taxpayer_id }}')">Открыть</button></td>
     </tr>
   {% endfor %}
   </tbody>
 </table>
+  {% if pages > 1 %}
+  <nav>
+    <ul class="pagination">
+      <li class="page-item {% if page <= 1 %}disabled{% endif %}">
+        <a class="page-link" href="?query={{ query }}&page={{ page - 1 }}">&laquo;</a>
+      </li>
+      {% for p in range(1, pages + 1) %}
+      <li class="page-item {% if p == page %}active{% endif %}">
+        <a class="page-link" href="?query={{ query }}&page={{ p }}">{{ p }}</a>
+      </li>
+      {% endfor %}
+      <li class="page-item {% if page >= pages %}disabled{% endif %}">
+        <a class="page-link" href="?query={{ query }}&page={{ page + 1 }}">&raquo;</a>
+      </li>
+    </ul>
+  </nav>
+  {% endif %}
 {% else %}
 <p>Ничего не найдено</p>
 {% endif %}
+<div class="modal fade" id="taxpayerModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Налогоплательщик</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body" id="taxpayerDetails">
+      </div>
+    </div>
+  </div>
+</div>
+<script>
+async function openTaxpayer(id) {
+  const resp = await fetch('/taxpayers/' + id);
+  const modalEl = document.getElementById('taxpayerModal');
+  const details = document.getElementById('taxpayerDetails');
+  if (resp.ok) {
+    const tp = await resp.json();
+    let html = '<table class="table table-bordered">';
+    html += `<tr><th>ИНН</th><td>${tp.taxpayer_id}</td></tr>`;
+    if (tp.company_name) {
+      html += `<tr><th>Компания</th><td>${tp.company_name}</td></tr>`;
+    } else {
+      const fio = [tp.last_name || '', tp.first_name || '', tp.middle_name || ''].join(' ');
+      html += `<tr><th>ФИО</th><td>${fio.trim()}</td></tr>`;
+    }
+    html += `<tr><th>Тип</th><td>${tp.type}</td></tr>`;
+    if (tp.phone) html += `<tr><th>Телефон</th><td>${tp.phone}</td></tr>`;
+    if (tp.email) html += `<tr><th>Email</th><td>${tp.email}</td></tr>`;
+    details.innerHTML = html + '</table>';
+  } else {
+    details.textContent = 'Ошибка загрузки данных';
+  }
+  const modal = new bootstrap.Modal(modalEl);
+  modal.show();
+}
+</script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- compute total debt per taxpayer
- show debt column and open details in modal
- use standard container width in navbar

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6850e786d054832c9a205de99c56e244