### PR TITLE
Fix debt penalty calculation with Decimal

### DIFF
--- a/app/crud/debt.py
+++ b/app/crud/debt.py
@@ -1,5 +1,6 @@
 from datetime import date
 from typing import List
+from decimal import Decimal
 
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.future import select
@@ -7,7 +8,7 @@ from sqlalchemy.future import select
 from app.models import Accrual, Debt
 
 # Fixed reference rate used in README examples
-REF_RATE = 7.50
+REF_RATE = Decimal("7.50")
 
 
 async def calculate_debts(db: AsyncSession, taxpayer_id: str) -> List[Debt]:
@@ -22,7 +23,7 @@ async def calculate_debts(db: AsyncSession, taxpayer_id: str) -> List[Debt]:
     accruals = result.scalars().all()
 
     for accrual in accruals:
-        principal = float(accrual.amount) - float(accrual.paid_amount)
+        principal = Decimal(accrual.amount) - Decimal(accrual.paid_amount)
         if principal <= 0:
             continue
         debt_result = await db.execute(
@@ -33,7 +34,7 @@ async def calculate_debts(db: AsyncSession, taxpayer_id: str) -> List[Debt]:
             debt = Debt(
                 accrual_id=accrual.accrual_id,
                 principal_amount=principal,
-                penalty_amount=0,
+                penalty_amount=Decimal("0.00"),
                 penalty_date=today,
                 status='активно',
             )
@@ -43,9 +44,10 @@ async def calculate_debts(db: AsyncSession, taxpayer_id: str) -> List[Debt]:
             if debt.status == 'активно':
                 days = (today - debt.penalty_date).days
                 if days > 0:
-                    debt.penalty_amount += round(
-                        float(debt.principal_amount) * REF_RATE / 300 * days, 2
-                    )
+                    penalty_increment = (
+                        debt.principal_amount * REF_RATE / Decimal(300) * days
+                    ).quantize(Decimal("0.01"))
+                    debt.penalty_amount += penalty_increment
                     debt.penalty_date = today
             if principal == 0:
                 debt.status = 'погашено'
@@ -61,8 +63,8 @@ async def calculate_debts(db: AsyncSession, taxpayer_id: str) -> List[Debt]:
 async def get_total_debt(db: AsyncSession, taxpayer_id: str) -> float:
     """Return total active debt (principal + penalty) for a taxpayer."""
     debts = await calculate_debts(db, taxpayer_id)
-    total = 0.0
+    total = Decimal("0.00")
     for debt in debts:
         if debt.status == "активно":
-            total += float(debt.principal_amount) + float(debt.penalty_amount)
-    return round(total, 2)
+            total += debt.principal_amount + debt.penalty_amount
+    return float(total.quantize(Decimal("0.01")))


### PR DESCRIPTION
## Summary
- handle Numeric columns as Decimal values
- keep total debt calculation in Decimal to avoid type errors

## Testing
- `python -m py_compile app/crud/debt.py`

------
https://chatgpt.com/codex/tasks/task_e_6850ee54e73c832cb12be025137eaf4d