### PR TITLE
Fix join clause for debt retrieval

### DIFF
--- a/app/crud/debt.py
+++ b/app/crud/debt.py
@@ -55,7 +55,9 @@ async def calculate_debts(db: AsyncSession, taxpayer_id: str) -> List[Debt]:
     await db.commit()
 
     result = await db.execute(
-        select(Debt).join(Accrual).where(Accrual.taxpayer_id == taxpayer_id)
+        select(Debt)
+        .join(Accrual, Accrual.accrual_id == Debt.accrual_id)
+        .where(Accrual.taxpayer_id == taxpayer_id)
     )
     return result.scalars().all()
 


### PR DESCRIPTION
## Summary
- fix join condition when computing debts to avoid ambiguity

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6850ef8d6c08832c913427a8b4f1b113