### PR TITLE
Fix root validator for pydantic 2

### DIFF
--- a/app/schemas/taxpayer.py
+++ b/app/schemas/taxpayer.py
@@ -37,7 +37,7 @@ class TaxpayerBase(BaseModel):
 
 
 class TaxpayerCreate(TaxpayerBase):
-    @root_validator
+    @root_validator(skip_on_failure=True)
     def check_required_fields(cls, values):
         tp_type = values.get('type')
         if tp_type == 'U':


### PR DESCRIPTION
## Summary
- add `skip_on_failure=True` to `TaxpayerCreate` validator

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68511b95e8e4832c8f4e4ed2325fdedd