### PR TITLE
Add optional contact fields & mandatory OGRN for legal entities

### DIFF
--- a/app/routes/web.py
+++ b/app/routes/web.py
@@ -80,6 +80,14 @@ async def create_taxpayer(
     first_name: str = Form(""),
     middle_name: str = Form(""),
     company_name: str = Form(""),
+    ogrn: str = Form(""),
+    region_code: str = Form(""),
+    city: str = Form(""),
+    street: str = Form(""),
+    house: str = Form(""),
+    apartment: str = Form(""),
+    phone: str = Form(""),
+    email: str = Form(""),
     db: AsyncSession = Depends(get_session),
 ):
     data = TaxpayerCreate(
@@ -89,6 +97,14 @@ async def create_taxpayer(
         first_name=first_name or None,
         middle_name=middle_name or None,
         company_name=company_name or None,
+        ogrn=ogrn or None,
+        region_code=int(region_code) if region_code else None,
+        city=city or None,
+        street=street or None,
+        house=house or None,
+        apartment=apartment or None,
+        phone=phone or None,
+        email=email or None,
     )
     await crud_create_taxpayer(db, data.dict())
     url = router.url_path_for("web.list_taxpayers")
@@ -122,6 +138,14 @@ async def update_taxpayer(
     first_name: str = Form(""),
     middle_name: str = Form(""),
     company_name: str = Form(""),
+    ogrn: str = Form(""),
+    region_code: str = Form(""),
+    city: str = Form(""),
+    street: str = Form(""),
+    house: str = Form(""),
+    apartment: str = Form(""),
+    phone: str = Form(""),
+    email: str = Form(""),
     db: AsyncSession = Depends(get_session),
 ):
     tp = await get_taxpayer(db, taxpayer_id)
@@ -133,6 +157,14 @@ async def update_taxpayer(
         first_name=first_name or None,
         middle_name=middle_name or None,
         company_name=company_name or None,
+        ogrn=ogrn or None,
+        region_code=int(region_code) if region_code else None,
+        city=city or None,
+        street=street or None,
+        house=house or None,
+        apartment=apartment or None,
+        phone=phone or None,
+        email=email or None,
     )
     await crud_update_taxpayer(db, tp, data.dict(exclude_unset=True))
     url = router.url_path_for("web.edit_taxpayer", taxpayer_id=taxpayer_id)

--- a/app/schemas/taxpayer.py
+++ b/app/schemas/taxpayer.py
@@ -43,6 +43,8 @@ class TaxpayerCreate(TaxpayerBase):
         if tp_type == 'U':
             if not values.get('company_name'):
                 raise ValueError('Название компании обязательно для юридического лица')
+            if not values.get('ogrn'):
+                raise ValueError('ОГРН обязателен для юридического лица')
         elif tp_type == 'F':
             if not values.get('last_name') or not values.get('first_name'):
                 raise ValueError('ФИО обязательно для физического лица')

--- a/app/templates/taxpayers/form.html
+++ b/app/templates/taxpayers/form.html
@@ -30,6 +30,42 @@
   <div id="company-group" class="mb-3 d-none">
     <label class="form-label">Название компании</label>
     <input type="text" name="company_name" class="form-control" value="{{ taxpayer.company_name or '' }}">
+    <div class="mt-3">
+      <label class="form-label">ОГРН</label>
+      <input type="text" name="ogrn" class="form-control" value="{{ taxpayer.ogrn or '' }}">
+    </div>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Код региона</label>
+    <input type="text" name="region_code" class="form-control" value="{{ taxpayer.region_code or '' }}">
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Город</label>
+    <input type="text" name="city" class="form-control" value="{{ taxpayer.city or '' }}">
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Улица</label>
+    <input type="text" name="street" class="form-control" value="{{ taxpayer.street or '' }}">
+  </div>
+  <div class="row">
+    <div class="col mb-3">
+      <label class="form-label">Дом</label>
+      <input type="text" name="house" class="form-control" value="{{ taxpayer.house or '' }}">
+    </div>
+    <div class="col mb-3">
+      <label class="form-label">Квартира</label>
+      <input type="text" name="apartment" class="form-control" value="{{ taxpayer.apartment or '' }}">
+    </div>
+  </div>
+  <div class="row">
+    <div class="col mb-3">
+      <label class="form-label">Телефон</label>
+      <input type="text" name="phone" class="form-control" value="{{ taxpayer.phone or '' }}">
+    </div>
+    <div class="col mb-3">
+      <label class="form-label">Email</label>
+      <input type="text" name="email" class="form-control" value="{{ taxpayer.email or '' }}">
+    </div>
   </div>
   <button type="submit" class="btn btn-primary">Сохранить</button>
 </form>

--- a/app/templates/taxpayers/list.html
+++ b/app/templates/taxpayers/list.html
@@ -106,6 +106,42 @@
           <div id="company-fields" class="mb-3 d-none">
             <label class="form-label">Название компании</label>
             <input type="text" name="company_name" class="form-control">
+            <div class="mt-3">
+              <label class="form-label">ОГРН</label>
+              <input type="text" name="ogrn" class="form-control">
+            </div>
+          </div>
+          <div class="mb-3">
+            <label class="form-label">Код региона</label>
+            <input type="text" name="region_code" class="form-control">
+          </div>
+          <div class="mb-3">
+            <label class="form-label">Город</label>
+            <input type="text" name="city" class="form-control">
+          </div>
+          <div class="mb-3">
+            <label class="form-label">Улица</label>
+            <input type="text" name="street" class="form-control">
+          </div>
+          <div class="row">
+            <div class="col mb-3">
+              <label class="form-label">Дом</label>
+              <input type="text" name="house" class="form-control">
+            </div>
+            <div class="col mb-3">
+              <label class="form-label">Квартира</label>
+              <input type="text" name="apartment" class="form-control">
+            </div>
+          </div>
+          <div class="row">
+            <div class="col mb-3">
+              <label class="form-label">Телефон</label>
+              <input type="text" name="phone" class="form-control">
+            </div>
+            <div class="col mb-3">
+              <label class="form-label">Email</label>
+              <input type="text" name="email" class="form-control">
+            </div>
           </div>
         </div>
         <div class="modal-footer">
@@ -147,7 +183,13 @@ async function loadTaxpayer(id) {
     lines.push(`<strong>ФИО:</strong> ${data.last_name || ''} ${data.first_name || ''} ${data.middle_name || ''}`);
   } else {
     lines.push(`<strong>Компания:</strong> ${data.company_name || ''}`);
+    if (data.ogrn) lines.push(`<strong>ОГРН:</strong> ${data.ogrn}`);
   }
+  if (data.region_code) lines.push(`<strong>Регион:</strong> ${data.region_code}`);
+  if (data.city) lines.push(`<strong>Город:</strong> ${data.city}`);
+  if (data.street) lines.push(`<strong>Улица:</strong> ${data.street}`);
+  if (data.house) lines.push(`<strong>Дом:</strong> ${data.house}`);
+  if (data.apartment) lines.push(`<strong>Квартира:</strong> ${data.apartment}`);
   if (data.phone) lines.push(`<strong>Телефон:</strong> ${data.phone}`);
   if (data.email) lines.push(`<strong>Email:</strong> ${data.email}`);
   document.getElementById('taxpayerModalBody').innerHTML = '<p>' + lines.join('</p><p>') + '</p>';
@@ -163,6 +205,14 @@ document.getElementById('addTaxpayerForm').addEventListener('submit', async func
     first_name: form.first_name ? form.first_name.value.trim() : "",
     middle_name: form.middle_name ? form.middle_name.value.trim() : "",
     company_name: form.company_name ? form.company_name.value.trim() : "",
+    ogrn: form.ogrn ? form.ogrn.value.trim() : "",
+    region_code: form.region_code ? form.region_code.value.trim() : "",
+    city: form.city ? form.city.value.trim() : "",
+    street: form.street ? form.street.value.trim() : "",
+    house: form.house ? form.house.value.trim() : "",
+    apartment: form.apartment ? form.apartment.value.trim() : "",
+    phone: form.phone ? form.phone.value.trim() : "",
+    email: form.email ? form.email.value.trim() : "",
   };
   const errorBox = document.getElementById('add-error');
   errorBox.classList.add('d-none');
@@ -179,6 +229,11 @@ document.getElementById('addTaxpayerForm').addEventListener('submit', async func
   }
   if (data.type === 'U' && !data.company_name) {
     errorBox.textContent = 'Введите название компании';
+    errorBox.classList.remove('d-none');
+    return;
+  }
+  if (data.type === 'U' && !data.ogrn) {
+    errorBox.textContent = 'Введите ОГРН';
     errorBox.classList.remove('d-none');
     return;
   }


### PR DESCRIPTION
## Summary
- require `ogrn` when creating a legal entity
- accept contact and address fields in web routes
- extend taxpayer create/update forms with address & contact inputs
- update quick-add modal to support new fields and validation

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68515f27256c832c868adaec305f042d