### PR TITLE
Add declarations page via web

### DIFF
--- a/app/routes/web.py
+++ b/app/routes/web.py
@@ -172,15 +172,11 @@ async def update_taxpayer(
 
 
 @router.get("/declarations/new", name="web.add_declaration")
-async def new_declaration_form(request: Request, taxpayer_id: str):
-    return templates.TemplateResponse(
-        "declarations/form.html",
-        {
-            "request": request,
-            "taxpayer": {"taxpayer_id": taxpayer_id},
-            "active_tab": "declarations",
-        },
-    )
+async def new_declaration_form(request: Request, taxpayer_id: str = ""):
+    context = {"request": request, "active_tab": "declarations"}
+    if taxpayer_id:
+        context["taxpayer"] = {"taxpayer_id": taxpayer_id}
+    return templates.TemplateResponse("declarations/form.html", context)
 
 
 @router.post("/declarations/new")

--- a/app/templates/declarations/form.html
+++ b/app/templates/declarations/form.html
@@ -1,9 +1,16 @@
 {% extends 'layout.html' %}
 {% block title %}Новая декларация{% endblock %}
 {% block content %}
-<h3>Новая декларация для {{ taxpayer.taxpayer_id }}</h3>
+<h3>Новая декларация{% if taxpayer %} для {{ taxpayer.taxpayer_id }}{% endif %}</h3>
 <form method="post">
+  {% if taxpayer %}
   <input type="hidden" name="taxpayer_id" value="{{ taxpayer.taxpayer_id }}">
+  {% else %}
+  <div class="mb-3">
+    <label class="form-label">ИНН</label>
+    <input type="text" name="taxpayer_id" class="form-control" required>
+  </div>
+  {% endif %}
   <div class="mb-3">
     <label class="form-label">Вид налога</label>
     <input type="text" name="tax_type_id" class="form-control" required>

--- a/app/templates/layout.html
+++ b/app/templates/layout.html
@@ -15,7 +15,7 @@
           <a class="nav-link {% if active_tab=='taxpayers' %}active{% endif %}" href="{{ url_for('web.list_taxpayers') }}">Налогоплательщики</a>
         </li>
         <li class="nav-item">
-          <a class="nav-link {% if active_tab=='declarations' %}active{% endif %}" href="#">Декларации</a>
+          <a class="nav-link {% if active_tab=='declarations' %}active{% endif %}" href="{{ url_for('web.add_declaration') }}">Декларации</a>
         </li>
         <li class="nav-item">
           <a class="nav-link {% if active_tab=='payments' %}active{% endif %}" href="#">Платежи</a>


### PR DESCRIPTION
## Summary
- allow `/declarations/new` page without taxpayer param
- show taxpayer id field when not provided
- link Declarations tab to the new page

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_685161762214832ca6594b1621052a1b