### PR TITLE
Add declarations listing page

### DIFF
--- a/app/crud/__init__.py
+++ b/app/crud/__init__.py
@@ -5,27 +5,34 @@ from .taxpayer import (
     create_taxpayer,
     update_taxpayer,
 )
-from .declaration import get_declaration, create_declaration
+from .declaration import (
+    get_declaration,
+    create_declaration,
+    search_declarations,
+    count_declarations,
+)
 from .payment import get_payment, create_payment
 from .debt import calculate_debts, get_total_debt
 from .inspection import get_inspection, list_inspections, create_inspection
 from .report import tax_revenue_report, debtors_list
 
 __all__ = [
-    'get_taxpayer',
-    'search_taxpayers',
-    'count_taxpayers',
-    'create_taxpayer',
-    'update_taxpayer',
-    'get_declaration',
-    'create_declaration',
-    'get_payment',
-    'create_payment',
-    'calculate_debts',
-    'get_total_debt',
-    'get_inspection',
-    'list_inspections',
-    'create_inspection',
-    'tax_revenue_report',
-    'debtors_list',
+    "get_taxpayer",
+    "search_taxpayers",
+    "count_taxpayers",
+    "create_taxpayer",
+    "update_taxpayer",
+    "get_declaration",
+    "create_declaration",
+    "search_declarations",
+    "count_declarations",
+    "get_payment",
+    "create_payment",
+    "calculate_debts",
+    "get_total_debt",
+    "get_inspection",
+    "list_inspections",
+    "create_inspection",
+    "tax_revenue_report",
+    "debtors_list",
 ]

--- a/app/crud/declaration.py
+++ b/app/crud/declaration.py
@@ -1,6 +1,7 @@
 from datetime import timedelta
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.future import select
+from sqlalchemy import func
 
 from app.models.taxdeclaration import TaxDeclaration
 from app.models.accrual import Accrual
@@ -30,3 +31,32 @@ async def create_declaration(db: AsyncSession, data: dict) -> TaxDeclaration:
     await db.commit()
     await db.refresh(declaration)
     return declaration
+
+
+async def search_declarations(
+    db: AsyncSession, query: str, limit: int = 20, offset: int = 0
+) -> list[TaxDeclaration]:
+    """Search declarations by taxpayer ID or tax type."""
+    stmt = select(TaxDeclaration)
+    if query:
+        like_pattern = f"%{query}%"
+        stmt = stmt.where(
+            (TaxDeclaration.taxpayer_id == query)
+            | (TaxDeclaration.tax_type_id.ilike(like_pattern))
+        )
+    stmt = stmt.order_by(TaxDeclaration.declaration_id).offset(offset).limit(limit)
+    result = await db.execute(stmt)
+    return result.scalars().all()
+
+
+async def count_declarations(db: AsyncSession, query: str) -> int:
+    """Return number of declarations matching the query."""
+    stmt = select(func.count()).select_from(TaxDeclaration)
+    if query:
+        like_pattern = f"%{query}%"
+        stmt = stmt.where(
+            (TaxDeclaration.taxpayer_id == query)
+            | (TaxDeclaration.tax_type_id.ilike(like_pattern))
+        )
+    result = await db.execute(stmt)
+    return result.scalar_one()

--- a/app/templates/declarations/list.html
+++ b/app/templates/declarations/list.html
@@ -1,0 +1,57 @@
+{% extends 'layout.html' %}
+{% block title %}Декларации{% endblock %}
+{% block content %}
+<form method="get" class="mb-3">
+  <div class="input-group">
+    <input type="text" name="query" class="form-control" placeholder="ИНН или вид налога" value="{{ query or '' }}">
+    <button type="submit" class="btn btn-outline-primary">Поиск</button>
+    <a href="{{ url_for('web.add_declaration') }}" class="btn btn-primary ms-2">Добавить</a>
+  </div>
+  <input type="hidden" name="page" value="1">
+</form>
+{% if declarations %}
+<table class="table table-bordered">
+  <thead>
+    <tr>
+      <th>ID</th>
+      <th>ИНН</th>
+      <th>Налог</th>
+      <th>Период</th>
+      <th>Сумма</th>
+      <th>Статус</th>
+    </tr>
+  </thead>
+  <tbody>
+  {% for d in declarations %}
+    <tr>
+      <td>{{ d.declaration_id }}</td>
+      <td>{{ d.taxpayer_id }}</td>
+      <td>{{ d.tax_type_id }}</td>
+      <td>{{ d.period }}</td>
+      <td>{{ '%.2f'|format(d.declared_tax_amount) }}</td>
+      <td>{{ d.status }}</td>
+    </tr>
+  {% endfor %}
+  </tbody>
+</table>
+  {% if pages > 1 %}
+  <nav>
+    <ul class="pagination">
+      <li class="page-item {% if page <= 1 %}disabled{% endif %}">
+        <a class="page-link" href="?query={{ query }}&page={{ page - 1 }}">&laquo;</a>
+      </li>
+      {% for p in range(1, pages + 1) %}
+      <li class="page-item {% if p == page %}active{% endif %}">
+        <a class="page-link" href="?query={{ query }}&page={{ p }}">{{ p }}</a>
+      </li>
+      {% endfor %}
+      <li class="page-item {% if page >= pages %}disabled{% endif %}">
+        <a class="page-link" href="?query={{ query }}&page={{ page + 1 }}">&raquo;</a>
+      </li>
+    </ul>
+  </nav>
+  {% endif %}
+{% else %}
+<p>Ничего не найдено</p>
+{% endif %}
+{% endblock %}

--- a/app/templates/layout.html
+++ b/app/templates/layout.html
@@ -15,7 +15,7 @@
           <a class="nav-link {% if active_tab=='taxpayers' %}active{% endif %}" href="{{ url_for('web.list_taxpayers') }}">Налогоплательщики</a>
         </li>
         <li class="nav-item">
-          <a class="nav-link {% if active_tab=='declarations' %}active{% endif %}" href="{{ url_for('web.add_declaration') }}">Декларации</a>
+          <a class="nav-link {% if active_tab=='declarations' %}active{% endif %}" href="{{ url_for('web.list_declarations') }}">Декларации</a>
         </li>
         <li class="nav-item">
           <a class="nav-link {% if active_tab=='payments' %}active{% endif %}" href="#">Платежи</a>


### PR DESCRIPTION
## Summary
- add Jinja template for listing declarations
- expose search/count functions and listing route for declarations
- update navigation link to open the list

## Testing
- `black app/crud/declaration.py app/crud/__init__.py app/routes/web.py`

------
https://chatgpt.com/codex/tasks/task_e_685162fd0bf8832c93abd66efeb966c5