### PR TITLE
Fix declaration form path and add tax type dropdown

### DIFF
--- a/app/crud/__init__.py
+++ b/app/crud/__init__.py
@@ -15,6 +15,7 @@ from .payment import get_payment, create_payment
 from .debt import calculate_debts, get_total_debt
 from .inspection import get_inspection, list_inspections, create_inspection
 from .report import tax_revenue_report, debtors_list
+from .taxtype import list_tax_types
 
 __all__ = [
     "get_taxpayer",
@@ -35,4 +36,5 @@ __all__ = [
     "create_inspection",
     "tax_revenue_report",
     "debtors_list",
+    "list_tax_types",
 ]

--- a/app/crud/taxtype.py
+++ b/app/crud/taxtype.py
@@ -1,0 +1,8 @@
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.future import select
+
+from app.models.taxtype import TaxType
+
+async def list_tax_types(db: AsyncSession) -> list[TaxType]:
+    result = await db.execute(select(TaxType).order_by(TaxType.tax_type_id))
+    return result.scalars().all()

--- a/app/routes/__init__.py
+++ b/app/routes/__init__.py
@@ -11,17 +11,21 @@ from . import (
 )
 
 api_router = APIRouter()
-api_router.include_router(taxpayers.router, prefix="/taxpayers", tags=["Taxpayers"])
+
+# Mount API endpoints under /api to avoid conflicts with HTML routes
+api_router.include_router(taxpayers.router, prefix="/api/taxpayers", tags=["Taxpayers"])
 api_router.include_router(
-    declarations.router, prefix="/declarations", tags=["Declarations"]
+    declarations.router, prefix="/api/declarations", tags=["Declarations"]
 )
-api_router.include_router(payments.router, prefix="/payments", tags=["Payments"])
-api_router.include_router(debts.router, prefix="/debts", tags=["Debts"])
+api_router.include_router(payments.router, prefix="/api/payments", tags=["Payments"])
+api_router.include_router(debts.router, prefix="/api/debts", tags=["Debts"])
 api_router.include_router(
-    inspections.router, prefix="/inspections", tags=["Inspections"]
+    inspections.router, prefix="/api/inspections", tags=["Inspections"]
 )
-api_router.include_router(reports.router, prefix="/reports", tags=["Reports"])
-api_router.include_router(backup.router, prefix="/backup", tags=["Backup"])
+api_router.include_router(reports.router, prefix="/api/reports", tags=["Reports"])
+api_router.include_router(backup.router, prefix="/api/backup", tags=["Backup"])
+
+# Web interface routes remain without the /api prefix
 api_router.include_router(web.router, prefix="", tags=["Web"])
 
 __all__ = ["api_router"]

--- a/app/routes/web.py
+++ b/app/routes/web.py
@@ -14,6 +14,7 @@ from app.crud import (
     create_declaration as crud_create_declaration,
     search_declarations,
     count_declarations,
+    list_tax_types,
     get_total_debt,
 )
 from app.schemas import TaxpayerCreate, TaxpayerUpdate, TaxDeclarationCreate
@@ -199,8 +200,18 @@ async def list_declarations(
 
 
 @router.get("/declarations/new", name="web.add_declaration")
-async def new_declaration_form(request: Request, taxpayer_id: str = ""):
-    context = {"request": request, "active_tab": "declarations"}
+async def new_declaration_form(
+    request: Request,
+    taxpayer_id: str = "",
+    db: AsyncSession = Depends(get_session),
+):
+    tax_types = await list_tax_types(db)
+
+    context = {
+        "request": request,
+        "active_tab": "declarations",
+        "tax_types": tax_types,
+    }
     if taxpayer_id:
         context["taxpayer"] = {"taxpayer_id": taxpayer_id}
     return templates.TemplateResponse("declarations/form.html", context)

--- a/app/templates/declarations/form.html
+++ b/app/templates/declarations/form.html
@@ -13,7 +13,14 @@
   {% endif %}
   <div class="mb-3">
     <label class="form-label">Вид налога</label>
-    <input type="text" name="tax_type_id" class="form-control" required>
+    <select name="tax_type_id" id="tax-type" class="form-select" required>
+      {% for t in tax_types %}
+      <option value="{{ t.tax_type_id }}" data-desc="{{ t.description }}">
+        {{ t.tax_name }}
+      </option>
+      {% endfor %}
+    </select>
+    <div class="form-text" id="tax-desc"></div>
   </div>
   <div class="mb-3">
     <label class="form-label">Период (год)</label>
@@ -29,4 +36,16 @@
   </div>
   <button type="submit" class="btn btn-primary">Создать</button>
 </form>
+<script>
+const typeSelect = document.getElementById('tax-type');
+const descEl = document.getElementById('tax-desc');
+
+function updateDesc() {
+  const opt = typeSelect.options[typeSelect.selectedIndex];
+  descEl.textContent = opt.dataset.desc || '';
+}
+
+typeSelect.addEventListener('change', updateDesc);
+updateDesc();
+</script>
 {% endblock %}

--- a/app/templates/taxpayers/list.html
+++ b/app/templates/taxpayers/list.html
@@ -171,7 +171,7 @@ function toggleFields() {
 typeSelect.addEventListener('change', toggleFields);
 toggleFields();
 async function loadTaxpayer(id) {
-  const res = await fetch(`/taxpayers/${id}`);
+  const res = await fetch(`/api/taxpayers/${id}`);
   if (!res.ok) {
     document.getElementById('taxpayerModalBody').innerHTML = 'Ошибка загрузки';
     return;
@@ -243,7 +243,7 @@ document.getElementById('addTaxpayerForm').addEventListener('submit', async func
     return;
   }
 
-  const res = await fetch('/taxpayers/', {
+  const res = await fetch('/api/taxpayers/', {
     method: 'POST',
     headers: {'Content-Type': 'application/json'},
     body: JSON.stringify(data)


### PR DESCRIPTION
## Summary
- avoid route conflicts by mounting API endpoints under `/api`
- fetch tax types for declaration form
- show dropdown with tax type descriptions
- adjust JS calls to use new `/api` prefix

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851650b1250832caae735dd3ea158d1