### PR TITLE
Implement taxpayer autocomplete and change declaration redirect

### DIFF
--- a/app/crud/__init__.py
+++ b/app/crud/__init__.py
@@ -4,6 +4,7 @@ from .taxpayer import (
     count_taxpayers,
     create_taxpayer,
     update_taxpayer,
+    autocomplete_taxpayers,
 )
 from .declaration import (
     get_declaration,
@@ -23,6 +24,7 @@ __all__ = [
     "count_taxpayers",
     "create_taxpayer",
     "update_taxpayer",
+    "autocomplete_taxpayers",
     "get_declaration",
     "create_declaration",
     "search_declarations",

--- a/app/crud/taxpayer.py
+++ b/app/crud/taxpayer.py
@@ -49,6 +49,22 @@ async def count_taxpayers(db: AsyncSession, query: str) -> int:
     return result.scalar_one()
 
 
+async def autocomplete_taxpayers(
+    db: AsyncSession, prefix: str, limit: int = 5
+) -> List[Taxpayer]:
+    """Return taxpayers whose ID starts with the given prefix."""
+    if not prefix:
+        return []
+    stmt = (
+        select(Taxpayer)
+        .where(Taxpayer.taxpayer_id.like(f"{prefix}%"))
+        .order_by(Taxpayer.taxpayer_id)
+        .limit(limit)
+    )
+    result = await db.execute(stmt)
+    return result.scalars().all()
+
+
 async def create_taxpayer(db: AsyncSession, data: dict) -> Taxpayer:
     taxpayer = Taxpayer(**data)
     db.add(taxpayer)

--- a/app/routes/taxpayers.py
+++ b/app/routes/taxpayers.py
@@ -10,10 +10,20 @@ from app.crud import (
     count_taxpayers,
     create_taxpayer,
     update_taxpayer,
+    autocomplete_taxpayers,
 )
 from app.schemas import TaxpayerCreate, TaxpayerUpdate, TaxpayerRead
 
 router = APIRouter()
+
+
+@router.get('/autocomplete', response_model=List[TaxpayerRead])
+async def autocomplete(
+    query: str,
+    limit: int = 5,
+    db: AsyncSession = Depends(get_session),
+):
+    return await autocomplete_taxpayers(db, query, limit=limit)
 
 
 @router.get('/search', response_model=List[TaxpayerRead])

--- a/app/routes/web.py
+++ b/app/routes/web.py
@@ -235,5 +235,5 @@ async def create_declaration(
         declared_tax_amount=declared_tax_amount,
     )
     await crud_create_declaration(db, data.dict())
-    url = router.url_path_for("web.edit_taxpayer", taxpayer_id=taxpayer_id)
+    url = router.url_path_for("web.list_taxpayers")
     return RedirectResponse(url, status_code=303)

--- a/app/templates/declarations/form.html
+++ b/app/templates/declarations/form.html
@@ -8,7 +8,8 @@
   {% else %}
   <div class="mb-3">
     <label class="form-label">ИНН</label>
-    <input type="text" name="taxpayer_id" class="form-control" required>
+    <input type="text" name="taxpayer_id" id="taxpayer-id" class="form-control" list="tp-suggest" autocomplete="off" required>
+    <datalist id="tp-suggest"></datalist>
   </div>
   {% endif %}
   <div class="mb-3">
@@ -39,6 +40,8 @@
 <script>
 const typeSelect = document.getElementById('tax-type');
 const descEl = document.getElementById('tax-desc');
+const tpInput = document.getElementById('taxpayer-id');
+const tpList = document.getElementById('tp-suggest');
 
 function updateDesc() {
   const opt = typeSelect.options[typeSelect.selectedIndex];
@@ -47,5 +50,26 @@ function updateDesc() {
 
 typeSelect.addEventListener('change', updateDesc);
 updateDesc();
+
+async function updateSuggestions() {
+  const q = tpInput.value.trim();
+  if (q.length < 3) {
+    tpList.innerHTML = '';
+    return;
+  }
+  try {
+    const res = await fetch(`/api/taxpayers/autocomplete?query=${encodeURIComponent(q)}`);
+    if (!res.ok) return;
+    const items = await res.json();
+    tpList.innerHTML = items.map(tp => {
+      const name = tp.company_name || `${tp.last_name || ''} ${tp.first_name || ''} ${tp.middle_name || ''}`;
+      return `<option value="${tp.taxpayer_id}">${name.trim()}</option>`;
+    }).join('');
+  } catch {}
+}
+
+if (tpInput) {
+  tpInput.addEventListener('input', updateSuggestions);
+}
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- show taxpayer hints in the declaration form using a new autocomplete API
- route creation of declarations back to the taxpayers list page
- add API endpoint for taxpayer autocomplete

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685168cae050832c98c14bc304c20fae