### PR TITLE
Add payments listing page

### DIFF
--- a/app/crud/__init__.py
+++ b/app/crud/__init__.py
@@ -12,7 +12,12 @@ from .declaration import (
     search_declarations,
     count_declarations,
 )
-from .payment import get_payment, create_payment
+from .payment import (
+    get_payment,
+    create_payment,
+    search_payments,
+    count_payments,
+)
 from .debt import calculate_debts, get_total_debt
 from .inspection import get_inspection, list_inspections, create_inspection
 from .report import tax_revenue_report, debtors_list
@@ -31,6 +36,8 @@ __all__ = [
     "count_declarations",
     "get_payment",
     "create_payment",
+    "search_payments",
+    "count_payments",
     "calculate_debts",
     "get_total_debt",
     "get_inspection",

--- a/app/crud/payment.py
+++ b/app/crud/payment.py
@@ -1,5 +1,6 @@
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.future import select
+from sqlalchemy import func, or_
 
 from app.models.payment import Payment
 from app.models.accrual import Accrual
@@ -29,3 +30,26 @@ async def create_payment(db: AsyncSession, data: dict) -> Payment:
     await db.commit()
     await db.refresh(payment)
     return payment
+
+async def search_payments(
+    db: AsyncSession, query: str, limit: int = 20, offset: int = 0
+) -> list[Payment]:
+    stmt = select(Payment)
+    if query:
+        conditions = [Payment.taxpayer_id == query]
+        if query.isdigit():
+            conditions.append(Payment.payment_id == int(query))
+        stmt = stmt.where(or_(*conditions))
+    stmt = stmt.order_by(Payment.payment_id).offset(offset).limit(limit)
+    result = await db.execute(stmt)
+    return result.scalars().all()
+
+async def count_payments(db: AsyncSession, query: str) -> int:
+    stmt = select(func.count()).select_from(Payment)
+    if query:
+        conditions = [Payment.taxpayer_id == query]
+        if query.isdigit():
+            conditions.append(Payment.payment_id == int(query))
+        stmt = stmt.where(or_(*conditions))
+    result = await db.execute(stmt)
+    return result.scalar_one()

--- a/app/templates/layout.html
+++ b/app/templates/layout.html
@@ -18,7 +18,7 @@
           <a class="nav-link {% if active_tab=='declarations' %}active{% endif %}" href="{{ url_for('web.list_declarations') }}">Декларации</a>
         </li>
         <li class="nav-item">
-          <a class="nav-link {% if active_tab=='payments' %}active{% endif %}" href="#">Платежи</a>
+          <a class="nav-link {% if active_tab=='payments' %}active{% endif %}" href="{{ url_for('web.list_payments') }}">Платежи</a>
         </li>
         <li class="nav-item">
           <a class="nav-link {% if active_tab=='reports' %}active{% endif %}" href="#">Отчёты</a>

--- a/app/templates/payments/form.html
+++ b/app/templates/payments/form.html
@@ -1,0 +1,48 @@
+{% extends 'layout.html' %}
+{% block title %}Новый платеж{% endblock %}
+{% block content %}
+<h3>Новый платеж</h3>
+<form method="post">
+  <div class="mb-3">
+    <label class="form-label">ИНН</label>
+    <input type="text" name="taxpayer_id" id="taxpayer-id" class="form-control" list="tp-suggest" autocomplete="off" required>
+    <datalist id="tp-suggest"></datalist>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">ID начисления</label>
+    <input type="number" name="accrual_id" class="form-control" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Дата платежа</label>
+    <input type="date" name="payment_date" class="form-control" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Сумма</label>
+    <input type="number" step="0.01" name="amount" class="form-control" required>
+  </div>
+  <button type="submit" class="btn btn-primary">Создать</button>
+</form>
+<script>
+const tpInput = document.getElementById('taxpayer-id');
+const tpList = document.getElementById('tp-suggest');
+async function updateSuggestions() {
+  const q = tpInput.value.trim();
+  if (q.length < 3) {
+    tpList.innerHTML = '';
+    return;
+  }
+  try {
+    const res = await fetch(`/api/taxpayers/autocomplete?query=${encodeURIComponent(q)}`);
+    if (!res.ok) return;
+    const items = await res.json();
+    tpList.innerHTML = items.map(tp => {
+      const name = tp.company_name || `${tp.last_name || ''} ${tp.first_name || ''} ${tp.middle_name || ''}`;
+      return `<option value="${tp.taxpayer_id}">${name.trim()}</option>`;
+    }).join('');
+  } catch {}
+}
+if (tpInput) {
+  tpInput.addEventListener('input', updateSuggestions);
+}
+</script>
+{% endblock %}

--- a/app/templates/payments/list.html
+++ b/app/templates/payments/list.html
@@ -1,0 +1,55 @@
+{% extends 'layout.html' %}
+{% block title %}Платежи{% endblock %}
+{% block content %}
+<form method="get" class="mb-3">
+  <div class="input-group">
+    <input type="text" name="query" class="form-control" placeholder="ИНН или ID платежа" value="{{ query or '' }}">
+    <button type="submit" class="btn btn-outline-primary">Поиск</button>
+    <a href="{{ url_for('web.add_payment') }}" class="btn btn-primary ms-2">Добавить</a>
+  </div>
+  <input type="hidden" name="page" value="1">
+</form>
+{% if payments %}
+<table class="table table-bordered">
+  <thead>
+    <tr>
+      <th>ID</th>
+      <th>ИНН</th>
+      <th>Начисление</th>
+      <th>Дата</th>
+      <th>Сумма</th>
+    </tr>
+  </thead>
+  <tbody>
+  {% for p in payments %}
+    <tr>
+      <td>{{ p.payment_id }}</td>
+      <td>{{ p.taxpayer_id }}</td>
+      <td>{{ p.accrual_id }}</td>
+      <td>{{ p.payment_date }}</td>
+      <td>{{ '%.2f'|format(p.amount) }}</td>
+    </tr>
+  {% endfor %}
+  </tbody>
+</table>
+  {% if pages > 1 %}
+  <nav>
+    <ul class="pagination">
+      <li class="page-item {% if page <= 1 %}disabled{% endif %}">
+        <a class="page-link" href="?query={{ query }}&page={{ page - 1 }}">&laquo;</a>
+      </li>
+      {% for p in range(1, pages + 1) %}
+      <li class="page-item {% if p == page %}active{% endif %}">
+        <a class="page-link" href="?query={{ query }}&page={{ p }}">{{ p }}</a>
+      </li>
+      {% endfor %}
+      <li class="page-item {% if page >= pages %}disabled{% endif %}">
+        <a class="page-link" href="?query={{ query }}&page={{ page + 1 }}">&raquo;</a>
+      </li>
+    </ul>
+  </nav>
+  {% endif %}
+{% else %}
+<p>Ничего не найдено</p>
+{% endif %}
+{% endblock %}


### PR DESCRIPTION
## Summary
- implement payment search and count functions
- expose new CRUD helpers
- add web routes and templates for payments
- wire navigation to payments page

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685c12d90da4832cb560c32ba135e972