### PR TITLE
Add declaration dropdown and debt update for payments

### DIFF
--- a/app/crud/__init__.py
+++ b/app/crud/__init__.py
@@ -11,6 +11,7 @@ from .declaration import (
     create_declaration,
     search_declarations,
     count_declarations,
+    list_declarations_by_taxpayer,
 )
 from .payment import (
     get_payment,
@@ -34,6 +35,7 @@ __all__ = [
     "create_declaration",
     "search_declarations",
     "count_declarations",
+    "list_declarations_by_taxpayer",
     "get_payment",
     "create_payment",
     "search_payments",

--- a/app/routes/declarations.py
+++ b/app/routes/declarations.py
@@ -2,20 +2,35 @@ from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.database import get_session
-from app.crud import get_declaration, create_declaration
-from app.schemas import TaxDeclarationCreate, TaxDeclarationRead
+from app.crud import (
+    get_declaration,
+    create_declaration,
+    list_declarations_by_taxpayer,
+)
+from app.schemas import (
+    TaxDeclarationCreate,
+    TaxDeclarationRead,
+    TaxDeclarationWithAccrual,
+)
 
 router = APIRouter()
 
 
-@router.post('/', response_model=TaxDeclarationRead)
+@router.post("/", response_model=TaxDeclarationRead)
 async def create(decl: TaxDeclarationCreate, db: AsyncSession = Depends(get_session)):
     return await create_declaration(db, decl.dict())
 
 
-@router.get('/{declaration_id}', response_model=TaxDeclarationRead)
+@router.get("/{declaration_id}", response_model=TaxDeclarationRead)
 async def read(declaration_id: int, db: AsyncSession = Depends(get_session)):
     declaration = await get_declaration(db, declaration_id)
     if not declaration:
-        raise HTTPException(status_code=404, detail='Declaration not found')
+        raise HTTPException(status_code=404, detail="Declaration not found")
     return declaration
+
+
+@router.get(
+    "/by_taxpayer/{taxpayer_id}", response_model=list[TaxDeclarationWithAccrual]
+)
+async def by_taxpayer(taxpayer_id: str, db: AsyncSession = Depends(get_session)):
+    return await list_declarations_by_taxpayer(db, taxpayer_id)

--- a/app/schemas/__init__.py
+++ b/app/schemas/__init__.py
@@ -1,5 +1,9 @@
 from .taxpayer import TaxpayerCreate, TaxpayerUpdate, TaxpayerRead
-from .declaration import TaxDeclarationCreate, TaxDeclarationRead
+from .declaration import (
+    TaxDeclarationCreate,
+    TaxDeclarationRead,
+    TaxDeclarationWithAccrual,
+)
 from .payment import PaymentCreate, PaymentRead
 from .accrual import AccrualRead
 from .debt import DebtRead
@@ -7,17 +11,18 @@ from .inspection import InspectionCreate, InspectionRead
 from .report import TaxRevenueItem, DebtorItem
 
 __all__ = [
-    'TaxpayerCreate',
-    'TaxpayerUpdate',
-    'TaxpayerRead',
-    'TaxDeclarationCreate',
-    'TaxDeclarationRead',
-    'PaymentCreate',
-    'PaymentRead',
-    'AccrualRead',
-    'DebtRead',
-    'InspectionCreate',
-    'InspectionRead',
-    'TaxRevenueItem',
-    'DebtorItem',
+    "TaxpayerCreate",
+    "TaxpayerUpdate",
+    "TaxpayerRead",
+    "TaxDeclarationCreate",
+    "TaxDeclarationRead",
+    "TaxDeclarationWithAccrual",
+    "PaymentCreate",
+    "PaymentRead",
+    "AccrualRead",
+    "DebtRead",
+    "InspectionCreate",
+    "InspectionRead",
+    "TaxRevenueItem",
+    "DebtorItem",
 ]

--- a/app/schemas/declaration.py
+++ b/app/schemas/declaration.py
@@ -23,3 +23,9 @@ class TaxDeclarationRead(TaxDeclarationBase):
 
     class Config:
         orm_mode = True
+
+
+class TaxDeclarationWithAccrual(TaxDeclarationRead):
+    """Declaration along with related accrual ID."""
+
+    accrual_id: int

--- a/app/templates/payments/form.html
+++ b/app/templates/payments/form.html
@@ -9,8 +9,10 @@
     <datalist id="tp-suggest"></datalist>
   </div>
   <div class="mb-3">
-    <label class="form-label">ID начисления</label>
-    <input type="number" name="accrual_id" class="form-control" required>
+    <label class="form-label">Декларация</label>
+    <select name="accrual_id" id="declaration-select" class="form-select" required disabled>
+      <option value="">Введите ИНН</option>
+    </select>
   </div>
   <div class="mb-3">
     <label class="form-label">Дата платежа</label>
@@ -25,6 +27,7 @@
 <script>
 const tpInput = document.getElementById('taxpayer-id');
 const tpList = document.getElementById('tp-suggest');
+const declSelect = document.getElementById('declaration-select');
 async function updateSuggestions() {
   const q = tpInput.value.trim();
   if (q.length < 3) {
@@ -43,6 +46,28 @@ async function updateSuggestions() {
 }
 if (tpInput) {
   tpInput.addEventListener('input', updateSuggestions);
+  tpInput.addEventListener('change', updateDeclarations);
 }
+
+async function updateDeclarations() {
+  const tid = tpInput.value.trim();
+  if (!tid) {
+    declSelect.innerHTML = '<option value="">Введите ИНН</option>';
+    declSelect.disabled = true;
+    return;
+  }
+  try {
+    const res = await fetch(`/api/declarations/by_taxpayer/${encodeURIComponent(tid)}`);
+    if (!res.ok) return;
+    const items = await res.json();
+    declSelect.innerHTML = items.map(d => {
+      const text = `${d.declaration_id} / ${d.tax_type_id} / ${d.period}`;
+      return `<option value="${d.accrual_id}">${text}</option>`;
+    }).join('');
+    declSelect.disabled = items.length === 0;
+  } catch {}
+}
+
+updateDeclarations();
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add JS to load declarations after entering taxpayer ID when creating a payment
- replace accrual ID input with declaration selector in the payment form
- return declarations by taxpayer in a new API endpoint
- recalc debts after creating payment

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `black app/crud/__init__.py app/crud/declaration.py app/crud/payment.py app/routes/declarations.py app/schemas/__init__.py app/schemas/declaration.py`


------
https://chatgpt.com/codex/tasks/task_e_685c1525b6a8832cb783400da5fecc0d