### PR TITLE
Fix debt doubling by respecting database triggers

### DIFF
--- a/app/crud/payment.py
+++ b/app/crud/payment.py
@@ -23,11 +23,7 @@ async def create_payment(db: AsyncSession, data: dict) -> Payment:
     payment = Payment(**data)
     db.add(payment)
 
-    accrual.paid_amount += data["amount"]
-    if accrual.paid_amount == accrual.amount:
-        accrual.status = "оплачено"
-    else:
-        accrual.status = "оплачено частично"
+    # Accrual paid amount and status are updated by database trigger
 
     await db.commit()
     await db.refresh(payment)


### PR DESCRIPTION
## Summary
- avoid manual accrual creation when adding a declaration
- stop double updating paid amount in payments

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ca3ae2e9c832ca33c3f71bcd5e32d